### PR TITLE
ieboilstart : incorrect command name

### DIFF
--- a/ieboilstart.ado
+++ b/ieboilstart.ado
@@ -1,7 +1,7 @@
 	*! version 2.0 24Oct2016  Kristoffer Bjarkefur kbjarkefur@worldbank.org
 
-	capture program drop ieboilstart2
-	program ieboilstart2 , rclass
+	capture program drop ieboilstart
+	program ieboilstart , rclass
 		
 	qui {
 	


### PR DESCRIPTION
In pre-github version of these commands a test name was used to avoid
conflicts, this test name was incorrectly kept when uploading to the SSC
server