### PR TITLE
Add subfolder option to iefolder - fix issue #92

### DIFF
--- a/src/ado_files/iefolder.ado
+++ b/src/ado_files/iefolder.ado
@@ -221,19 +221,15 @@ end
 cap program drop 	iefolder_newProject
 	program define	iefolder_newProject
 		
-		noi di "command ok" 
-		
 		args projectfolder newHandle
 		
-		noi di "args ok"
 		*Test if folder where to create new folder exist
 		checkFolderExists "$projectFolder" "parent"
 
 		*Test that the new folder does not already exist
 		checkFolderExists "$dataWorkFolder" "new"				
 		
-		noi di "folder check ok"
-		
+		*Create the main DataWork folder
 		mkdir "$dataWorkFolder"
 		
 		******************************
@@ -267,8 +263,6 @@ cap program drop 	iefolder_newItem
 	
 	args subHandle itemType itemName itemAbb subfolder
 	
-	di "new item command"
-	
 	**Test that the folder where the new folder will 
 	* be created exist and that a folder with the same
 	* name is created there already
@@ -292,12 +286,11 @@ cap program drop 	iefolder_newItem
 		local line : subinstr local line "\$"  "\\$"
 		local line : subinstr local line "\`"  "\\`"
 		
+		//di `"`line'"'
+		
 		**Run funtion to read old project master dofile to check if any 
 		* infomration should be added before this line
 		parseReadLine `"`line'"'
-		
-		di `"`line'"'
-		 
 		
 		if `r(ief_line)' == 0 {
 
@@ -307,8 +300,6 @@ cap program drop 	iefolder_newItem
 		}
 		else if `r(ief_line)' == 1 {
 
-			di `"  if "`itemType'" == "round" "'
-			
 			**This is a line of code with a devisor written by 
 			* iefodler. New additions to a section are always added right before an end of section line. 
 			return list
@@ -345,8 +336,6 @@ cap program drop 	iefolder_newItem
 				}
 			}
 			else if "`itemType'" == "round" { // test if round
-				
-				pause
 			
 				**This is NOT an end of section line. Nothing will be written here 
 				* but we test that there is no confict with previous names
@@ -430,9 +419,7 @@ cap program drop 	iefolder_newItem
 				file write		`subHandle' _col(4) _n	
 				
 				file write		`subHandle' `"`line'"' _n	
-				
 			}
-			
 			else {
 				*If none apply, just write the line
 				file write		`subHandle' `"`line'"' _n	
@@ -657,7 +644,8 @@ cap program drop 	createFolderWriteGlobal
 		if ("`subHandle'" != "") {
 			writeGlobal "`folderName'" `parentGlobal' `globalName' `subHandle' "`subfolder'"
 		}
-
+		
+		*Create the folder
 		mkdir "${`parentGlobal'}/`subfolder'`folderName'"
 				
 end
@@ -688,7 +676,7 @@ cap program drop 	writeDevisor
 		
 		local devisorLen = strlen("`devisor'")
 		
-		*Make all devisors at least 80 characters wide by adding stars
+		*Make all devisors at least 80 characters wide by adding stars (just aesthetic reasons)
 		if (`devisorLen' < 80) {
 			
 			local numStars = 80 - `devisorLen'
@@ -821,7 +809,6 @@ cap program drop 	testNameAvailible
 			local item "``number''"
 		}
 	}
-	
 	
 	*Test that subfolder was found
 	 if `subfolderFound' == 0 & "`subfolder'" != "" {
@@ -990,18 +977,14 @@ cap program drop 	mdofle_p1
 		
 		*Create master data folder and add global to folder in master do file
 		if "`rndName'" == "" createFolderWriteGlobal "EncryptedData"  "dataWorkFolder"  encryptFolder `subHandle' //For new project
-		if "`rndName'" != "" writeGlobal 			 "EncryptedData"  "dataWorkFolder"  encryptFolder `subHandle' //For new round
-		
-		
-		di "sub 1"
+		if "`rndName'" != "" writeGlobal 			 "EncryptedData"  "dataWorkFolder"  encryptFolder `subHandle' //For new rounds
 		
 		*For new main master do file
 		if "`rndName'" == "" {
 
-		
 			*Write sub devisor starting master and monitor data section section
 			writeDevisor `subHandle' 1 FolderGlobals endRounds	
-			di "sub 2"
+
 			*Write sub devisor starting master and monitor data section section
 			writeDevisor `subHandle' 1 End_FolderGlobals
 			
@@ -1014,8 +997,6 @@ cap program drop 	mdofle_p1
 			writeDevisor `subHandle' 1 FolderGlobals `rndName'		
 
 		}
-		
-		di "sub 9"
 
 end	
 

--- a/src/ado_files/iefolder.ado
+++ b/src/ado_files/iefolder.ado
@@ -976,7 +976,8 @@ cap program drop 	mdofle_p1
 		*Create master data folder and add global to folder in master do file
 		if "`rndName'" == "" createFolderWriteGlobal "EncryptedData"  "dataWorkFolder"  encryptFolder `subHandle' 
 		if "`rndName'" != "" writeGlobal 			 "EncryptedData"  "dataWorkFolder"  encryptFolder `subHandle' 
-
+		
+		writeNameLine `subHandle' new
 		
 		if "`rndName'" == "" {
 			*Write sub devisor starting master and monitor data section section
@@ -999,6 +1000,53 @@ cap program drop 	mdofle_p1
 
 
 end	
+
+	
+cap program drop 	writeNameLine
+	program define	writeNameLine
+	
+	args   subHandle type name line
+	
+	if "`type'" == "new" {
+		writeNameLine `subHandle' "rounds" 
+		writeNameLine `subHandle' "untObs"
+		writeNameLine `subHandle' "subFld"
+	}
+	else {
+		
+		*remove stars in the end of the line
+		local line = substr("`line'",1,strlen("`line'") - indexnot(reverse("`line'"),"*") + 1)
+		
+		if "`name'" == "" {
+			
+			*Start the new line
+			local line "*`type'"
+		
+		}
+		else {
+			
+			*add new name (and abbrevation if applicable) to line
+			local line "`line'*`name'"
+		}
+		
+		*Make all devisors at least 80 characters wide by adding stars
+		if (strlen("`line'") < 80) {
+			
+			local numStars = 80 - strlen("`line'")
+			local addedStars _dup(`numStars') _char(42)
+		}
+		
+		file write  `subHandle' _n "`line'" `addedStars'
+		
+		*If creating the lines the first time then add a warning text at the end
+		if "`type'" == "subFld" & "`name'" == "" {
+			file write  `subHandle' _n "*iefolder will not work properly if the lines above are edited" 
+		}
+	}
+	
+	
+	
+end
 
 	
 cap program drop 	mdofle_p2

--- a/src/ado_files/iefolder.ado
+++ b/src/ado_files/iefolder.ado
@@ -3,7 +3,7 @@
 cap program drop 	iefolder2
 	program define	iefolder2
 
-*qui {	
+qui {	
 	
 	syntax anything, PROJectfolder(string) [ABBreviation(string) SUBfolder(string)]
 	
@@ -167,7 +167,7 @@ cap program drop 	iefolder2
 			*Produce success output
 			noi di "{pstd}Command ran succesfully, for the round [`itemName'] the following folders and master dofile were created:{p_end}"
 			noi di "{phang2}1) [${`abbreviation'}]{p_end}"
-			noi di "{phang2}2) [${encryptFolder}/Round `itemName' Encrypted]{p_end}"
+			noi di "{phang2}2) [${`abbreviation'_encrypt}]{p_end}"
 			noi di "{phang2}3) [${`abbreviation'}/`itemName'_MasterDofile.do]{p_end}"
 		}
 		*Creating a new level of observation for master data set
@@ -193,7 +193,7 @@ cap program drop 	iefolder2
 			*Produce success output
 			noi di "{pstd}Command ran succesfully, for the subfolder [`itemName'] the following folders were created:{p_end}"
 			noi di "{phang2}1) [${dataWorkFolder}/`itemName']{p_end}"
-			noi di "{phang2}2) [${encryptFolder}/`itemName']{p_end}"
+			noi di "{phang2}2) [${encryptFolder}/Subfolder `itemName' Encrypted]{p_end}"
 		
 		}
 	}
@@ -205,7 +205,7 @@ cap program drop 	iefolder2
 	copy "`newTextFile'"  "$projectFolder/DataWork/Project_MasterDofile.do" , replace
 	
 	
-*}	
+}	
 end 	
 
 /************************************************************

--- a/src/ado_files/iefolder.ado
+++ b/src/ado_files/iefolder.ado
@@ -554,24 +554,17 @@ cap program drop 	newRndFolderAndGlobals
 		file write  `subHandle'	_col(4)"*`rndName' folder globals" _n
 
 		*Round main folder	
-		if "`masterType'" == "round"  	createFolderWriteGlobal "`rndName'" "`dtfld_glb'" "`rnd'" 	`subHandle'
-		if "`masterType'" == "project"  writeGlobal 			"`rndName'" "`dtfld_glb'" "`rnd'" 	`subHandle'
+		createFolderWriteGlobal "`rndName'" "`dtfld_glb'" "`rnd'" 	`subHandle'
 		
 		*Sub folders
-		
-		if "`masterType'" == "round"  	writeGlobal 			"Round `rndName' Encrypted" 	"encryptFolder" "`rnd'_encrypt" `subHandle'
-		if "`masterType'" == "round"  	createFolderWriteGlobal "DataSets" 	"`rnd'" 	"`rnd'_dt" 	`subHandle'
-		if "`masterType'" == "project"  writeGlobal 			"DataSets" 	"`rnd'" 	"`rnd'_dt" 	`subHandle'
-
-		if "`masterType'" == "round"  	createFolderWriteGlobal "Dofiles" 	"`rnd'"		"`rnd'_do" 	`subHandle'
-		if "`masterType'" == "project"  writeGlobal 			"Dofiles" 	"`rnd'"		"`rnd'_do" 	`subHandle'
-
-		if "`masterType'" == "round"  	createFolderWriteGlobal "Output" 	"`rnd'"		"`rnd'_out"	`subHandle'
-		if "`masterType'" == "project"  writeGlobal 			"Output" 	"`rnd'"		"`rnd'_out"	`subHandle'
+		writeGlobal 			"Round `rndName' Encrypted" 	"encryptFolder" "`rnd'_encrypt" `subHandle'
+		createFolderWriteGlobal "DataSets" 						"`rnd'" 		"`rnd'_dt" 		`subHandle'
+		createFolderWriteGlobal "Dofiles" 						"`rnd'"			"`rnd'_do" 		`subHandle'
+		createFolderWriteGlobal "Output" 						"`rnd'"			"`rnd'_out"		`subHandle'
 		
 		*This are never written to the master dofile, only created 
-		if "`masterType'" == "round" createFolderWriteGlobal "Documentation"  "`rnd'"	"`rnd'_doc"	
-		if "`masterType'" == "round" createFolderWriteGlobal "Questionnaire"  "`rnd'"	"`rnd'_quest"		
+		createFolderWriteGlobal "Documentation"  "`rnd'"	"`rnd'_doc"	
+		createFolderWriteGlobal "Questionnaire"  "`rnd'"	"`rnd'_quest"		
 	
 
 end
@@ -990,9 +983,7 @@ cap program drop 	mdofle_p1
 
 			*Write sub devisor starting master and monitor data section section
 			writeDevisor `subHandle' 1 FolderGlobals `rndName'		
-			di "sub 8"
-			*Write all main folders for this round
-			//newRndFolderAndGlobals 	`rndName' `rndAbb' "dataWorkFolder" `subHandle' round
+
 		}
 		
 		di "sub 9"

--- a/src/ado_files/iefolder.ado
+++ b/src/ado_files/iefolder.ado
@@ -557,7 +557,7 @@ cap program drop 	newRndFolderAndGlobals
 		createFolderWriteGlobal "`rndName'" "`dtfld_glb'" "`rnd'" 	`subHandle'
 		
 		*Sub folders
-		writeGlobal 			"Round `rndName' Encrypted" 	"encryptFolder" "`rnd'_encrypt" `subHandle'
+		createFolderWriteGlobal	"Round `rndName' Encrypted" 	"encryptFolder" "`rnd'_encrypt" `subHandle'
 		createFolderWriteGlobal "DataSets" 						"`rnd'" 		"`rnd'_dt" 		`subHandle'
 		createFolderWriteGlobal "Dofiles" 						"`rnd'"			"`rnd'_do" 		`subHandle'
 		createFolderWriteGlobal "Output" 						"`rnd'"			"`rnd'_out"		`subHandle'
@@ -586,24 +586,27 @@ cap program drop 	createRoundMasterDofile
 		di "hej3"
 		*Encrypted round sub-folder
 		file write  `roundHandle'	_n	_col(4)"*Encrypted round sub-folder globals" _n 
-		createFolderWriteGlobal "Round `rndName' Encrypted" 	"encryptFolder" "`rnd'_encrypt" `roundHandle'
+		writeGlobal				"Round `rndName' Encrypted" 	"encryptFolder" "`rnd'_encrypt" `roundHandle'
 		createFolderWriteGlobal "Raw Identified Data"  			"`rnd'_encrypt" "`rnd'_dtRaw" 	`roundHandle'
 		createFolderWriteGlobal "Dofiles Import"				"`rnd'_encrypt" "`rnd'_doImp" 	`roundHandle'
 		createFolderWriteGlobal "High Frequency Checks"			"`rnd'_encrypt" "`rnd'_HFC" 	`roundHandle'
 		di "hej4"
 		*DataSets sub-folder
 		file write  `roundHandle' _n	_col(4)"*DataSets sub-folder globals" _n
+		writeGlobal				"DataSets" 						"`rnd'" 		"`rnd'_dt" 		`roundHandle'
 		createFolderWriteGlobal "Intermediate" 					"`rnd'_dt" 		"`rnd'_dtInt" 	`roundHandle'
 		createFolderWriteGlobal "Final"  						"`rnd'_dt" 		"`rnd'_dtFin" 	`roundHandle'
 		
 		*Dofile sub-folder
 		file write  `roundHandle' _n	_col(4)"*Dofile sub-folder globals" _n
+		writeGlobal				"Dofiles" 						"`rnd'"			"`rnd'_do" 		`roundHandle'
 		createFolderWriteGlobal "Cleaning"				 		"`rnd'_do" 		"`rnd'_doCln" 	`roundHandle'
 		createFolderWriteGlobal "Construct"				 		"`rnd'_do" 		"`rnd'_doCon" 	`roundHandle'
 		createFolderWriteGlobal "Analysis"				 		"`rnd'_do" 		"`rnd'_doAnl" 	`roundHandle'
 		
 		*Output subfolders
 		file write  `roundHandle' _n	_col(4)"*Output sub-folder globals" _n
+		writeGlobal				"Output" 						"`rnd'"			"`rnd'_out"		`roundHandle'
 		createFolderWriteGlobal "Raw" 							"`rnd'_out"	 	"`rnd'_outRaw"	`roundHandle'		
 		createFolderWriteGlobal "Final" 						"`rnd'_out"		"`rnd'_outFin"	`roundHandle'
 	

--- a/src/ado_files/iefolder.ado
+++ b/src/ado_files/iefolder.ado
@@ -133,9 +133,10 @@ cap program drop 	iefolder2
 	
 	
 	*Create a global pointing to the main data folder
-	global projectFolder	"`projectfolder'"
-	global dataWorkFolder 	"$projectFolder/DataWork"
-	global encryptFolder 	"$dataWorkFolder/EncryptedData"
+	global projectFolder		"`projectfolder'"
+	global dataWorkFolder 		"$projectFolder/DataWork"
+	global encryptFolder 		"$dataWorkFolder/EncryptedData"
+	
 
 	if "`subcommand'" == "new" {
 	
@@ -160,7 +161,7 @@ cap program drop 	iefolder2
 		else if "`itemType'" == "round" {
 			
 			di "ItemType: round"
-			iefolder_newItem `newHandle' round "`itemName'" "`abbreviation'"	
+			iefolder_newItem `newHandle' round "`itemName'" "`abbreviation'" 
 			
 			*Produce success output
 			noi di "{pstd}Command ran succesfully, for the round [`itemName'] the following folders and master dofile were created:{p_end}"
@@ -200,7 +201,9 @@ cap program drop 	iefolder2
 	file close 		`newHandle'
 	
 	*Copy the new master dofile from the tempfile to the original position
-	copy "`newTextFile'"  "$dataWorkFolder/Project_MasterDofile.do" , replace
+	copy "`newTextFile'"  "$projectFolder/DataWork/Project_MasterDofile.do" , replace
+	
+	
 *}	
 end 	
 
@@ -270,7 +273,7 @@ cap program drop 	iefolder_newItem
 	
 	*Old file reference
 	tempname 	oldHandle
-	local 		oldTextFile 	"$dataWorkFolder/Project_MasterDofile.do"
+	local 		oldTextFile 	"$projectFolder/DataWork/Project_MasterDofile.do"
 
 	file open `oldHandle' using `"`oldTextFile'"', read
 	file read `oldHandle' line
@@ -351,7 +354,7 @@ cap program drop 	iefolder_newItem
 					di "hit1"
 					
 					*Create the round master dofile and create the subfolders for this round
-					createRoundMasterDofile "$dataWorkFolder/`itemName'" "`itemName'" "`itemAbb'"
+					createRoundMasterDofile "$dataWorkFolder/`itemName'" "`itemName'" "`itemAbb'" 
 					di "hit2"
 					
 					
@@ -557,10 +560,10 @@ cap program drop 	newRndFolderAndGlobals
 		createFolderWriteGlobal "`rndName'" "`dtfld_glb'" "`rnd'" 	`subHandle'
 		
 		*Sub folders
-		createFolderWriteGlobal	"Round `rndName' Encrypted" 	"encryptFolder" "`rnd'_encrypt" `subHandle'
-		createFolderWriteGlobal "DataSets" 						"`rnd'" 		"`rnd'_dt" 		`subHandle'
-		createFolderWriteGlobal "Dofiles" 						"`rnd'"			"`rnd'_do" 		`subHandle'
-		createFolderWriteGlobal "Output" 						"`rnd'"			"`rnd'_out"		`subHandle'
+		writeGlobal	"Round `rndName' Encrypted" 	"encryptFolder" "`rnd'_encrypt" `subHandle'
+		writeGlobal "DataSets" 						"`rnd'" 		"`rnd'_dt" 		`subHandle'
+		writeGlobal "Dofiles" 						"`rnd'"			"`rnd'_do" 		`subHandle'
+		writeGlobal "Output" 						"`rnd'"			"`rnd'_out"		`subHandle'
 		
 		*This are never written to the master dofile, only created 
 		createFolderWriteGlobal "Documentation"  "`rnd'"	"`rnd'_doc"	
@@ -572,7 +575,7 @@ end
 cap program drop 	createRoundMasterDofile 
 	program define	createRoundMasterDofile 	
 	
-		args roundfolder rndName rnd
+		args roundfolder rndName rnd 
 		di "hej1"
 		*Create a temporary textfile
 		tempname 	roundHandle
@@ -583,30 +586,31 @@ cap program drop 	createRoundMasterDofile
 		mdofle_p0 	`roundHandle' round
 		di "hej21"
 		mdofle_p1	`roundHandle' "$projectFolder" `rndName' `rnd'
+
 		di "hej3"
-		*Encrypted round sub-folder
+		*Encrypted round sub-folder		
 		file write  `roundHandle'	_n	_col(4)"*Encrypted round sub-folder globals" _n 
-		writeGlobal				"Round `rndName' Encrypted" 	"encryptFolder" "`rnd'_encrypt" `roundHandle'
+		createFolderWriteGlobal				"Round `rndName' Encrypted" 	"encryptFolder" "`rnd'_encrypt" `roundHandle'
 		createFolderWriteGlobal "Raw Identified Data"  			"`rnd'_encrypt" "`rnd'_dtRaw" 	`roundHandle'
 		createFolderWriteGlobal "Dofiles Import"				"`rnd'_encrypt" "`rnd'_doImp" 	`roundHandle'
 		createFolderWriteGlobal "High Frequency Checks"			"`rnd'_encrypt" "`rnd'_HFC" 	`roundHandle'
 		di "hej4"
 		*DataSets sub-folder
 		file write  `roundHandle' _n	_col(4)"*DataSets sub-folder globals" _n
-		writeGlobal				"DataSets" 						"`rnd'" 		"`rnd'_dt" 		`roundHandle'
+		createFolderWriteGlobal				"DataSets" 						"`rnd'" 		"`rnd'_dt" 		`roundHandle'
 		createFolderWriteGlobal "Intermediate" 					"`rnd'_dt" 		"`rnd'_dtInt" 	`roundHandle'
 		createFolderWriteGlobal "Final"  						"`rnd'_dt" 		"`rnd'_dtFin" 	`roundHandle'
 		
 		*Dofile sub-folder
 		file write  `roundHandle' _n	_col(4)"*Dofile sub-folder globals" _n
-		writeGlobal				"Dofiles" 						"`rnd'"			"`rnd'_do" 		`roundHandle'
+		createFolderWriteGlobal				"Dofiles" 						"`rnd'"			"`rnd'_do" 		`roundHandle'
 		createFolderWriteGlobal "Cleaning"				 		"`rnd'_do" 		"`rnd'_doCln" 	`roundHandle'
 		createFolderWriteGlobal "Construct"				 		"`rnd'_do" 		"`rnd'_doCon" 	`roundHandle'
 		createFolderWriteGlobal "Analysis"				 		"`rnd'_do" 		"`rnd'_doAnl" 	`roundHandle'
 		
 		*Output subfolders
 		file write  `roundHandle' _n	_col(4)"*Output sub-folder globals" _n
-		writeGlobal				"Output" 						"`rnd'"			"`rnd'_out"		`roundHandle'
+		createFolderWriteGlobal				"Output" 						"`rnd'"			"`rnd'_out"		`roundHandle'
 		createFolderWriteGlobal "Raw" 							"`rnd'_out"	 	"`rnd'_outRaw"	`roundHandle'		
 		createFolderWriteGlobal "Final" 						"`rnd'_out"		"`rnd'_outFin"	`roundHandle'
 	

--- a/src/help_files/iefolder.sthlp
+++ b/src/help_files/iefolder.sthlp
@@ -17,73 +17,75 @@ help for {hi:iefolder}
 
 {pstd} {ul:When adding folders to and already existing {hi:DataWork} folder:}{p_end}
 
-{phang2}{cmd:iefolder} new {it:itemtype} {it:itemname} , {cmdab:proj:ectfolder(}{it:directory}{cmd:)} 
-	[{cmdab:abb:reviation(}{it:string}{cmd:)}] {p_end}
-	
-{pmore}where {it:itemtype} is either {it:round} or {it:unitofobs}. See 
+{phang2}{cmd:iefolder} new {it:itemtype} {it:itemname} , {cmdab:proj:ectfolder(}{it:directory}{cmd:)}
+	[{cmdab:abb:reviation(}{it:string}{cmd:)} {cmdab:sub:folder(}{it:folder}{cmd:)}] {p_end}
+
+{pmore}where {it:itemtype} is either {it:round}, {it:unitofobs} or {it:subfolder}. See
 	details on {it:itemtype} and {it:itemname} below.{p_end}
 
 {marker opts}{...}
 {synoptset 22}{...}
 {synopthdr:options}
 {synoptline}
-{synopt : {cmdab:proj:ectfolder(}{it:dir}{cmd:)}}The location of 
-	the project folder where the {hi:DataWork} folder should be 
-	created (new projects), or where it is located (new round and new unitofobs).{p_end}
-{synopt : {cmdab:abb:reviation(}{it:string}{cmd:)}}Optional abbreviation 
-	of round name to be used to make globals shorter. Can only be used 
+{synopt : {cmdab:proj:ectfolder(}{it:dir}{cmd:)}}The location of
+	the project folder where the {hi:DataWork} folder should be
+	created (new projects), or where it is located (new rounds, unitofobs and subfolders).{p_end}
+{synopt : {cmdab:abb:reviation(}{it:string}{cmd:)}}Optional abbreviation
+	of round name to be used to make globals shorter. Can only be used
 	when {it:itemtype} is round.{p_end}
+{synopt : {cmdab:sub:folder(}{it:folder}{cmd:)}}Creates the round folders inside
+	a subfolder to DataWork. Only works with new rounds and only after the subfolder
+	has been created with {it:iefolder new subfolder}.{p_end}
 {synoptline}
 
 {marker desc}{title:Description}
 
-{pstd}{cmdab:iefolder} automates the process of setting up the folders and master do-files 
-	where all the data work will take place in a project folder. The folders set 
-	up will follow DIME's best practices outlined and explained here: 
-	{browse "https://dimewiki.worldbank.org/wiki/DataWork_Folder"} (This page 
-	is a part of a Wiki that we are in the final stage of getting approval to 
-	release externally, the page is until then unfortunately password protected.) 
+{pstd}{cmdab:iefolder} automates the process of setting up the folders and master do-files
+	where all the data work will take place in a project folder. The folder structure set
+	up by {cmdab:iefolder} follows {browse "https://dimewiki.worldbank.org/wiki/DataWork_Folder":DIME's best practices}.
 
-{pstd}In addition to setting up the {hi:DataWork} folder and its sub-folders, the 
-	command creates master do-files linking to all of these sub-folders. These 
-	master do-files are updated whenever more subfolders are added using this command.
-	
-{pstd}{ul:{hi:itemtypes}}. This command can create either a new DataWork folder or add folders to an 
-	existing DataWork folder. The existing DataWork folder must have been created 
-	with {cmd:iefolder} for the additions to work. There are two types of folders 
-	that can be added to an existing folder, {ul:round} and {ul:untiofobs}. See 
+{pstd}In addition to setting up the {hi:DataWork} folder and its folder structure, the
+	command creates master do-files linking to all main folders in the folder structure. These
+	master do-files are updated whenever more rounds, units of observations, and
+	subfolders are added to the project folder using this command.
+
+{pstd}{ul:{hi:itemtypes}}{break} This command can create either a new DataWork folder or add folders to an
+	existing DataWork folder. The existing DataWork folder must have been created
+	with {cmd:iefolder} for the additions to work. A new DataWork folder is created using specifying {ul:project}. There are three types of folders that can be added to an existing folder by specifying {ul:round}, {ul:untiofobs} or {ul:subfolder}. See
 	next paragraphs for descriptions.
-	
-{pstd}{hi:{it:round}} folders are folders specific to a data collection round, for example, {it:Baseline}, {it:Endline},
-	{it:Follow Up} etc. When adding a new round, sub-folders are added to the DataWork 
-	folder in line with the best practice described here:
-	{browse "https://dimewiki.worldbank.org/wiki/DataWork_Survey_Round"}. {cmd:iefolder} also 
-	creates a master do-file specific for this round with globals referencing the sub-folders
-	specific to this round. {cmd:iefolder} is implemented so that you can keep working 
-	for years with your project in between adding folders. The command reads and perserves 
-	changes made manually to the DataWork folder and master do-file before making additions
-	when adding a new round.
-	
-{pstd}{hi:{it:unitofobs}} folders are folders specific to a unit of observation, 
+
+{pstd}{ul:{it:project}} sets up a new DataWork folder and its initial folder structure. You must always do this before you can do anything else. It also sets up the main master do-file for this DataWork folder. {cmd:iefolder} is implemented so that you can keep working for years with your project in between adding folders. The command reads and preserves changes made manually to the DataWork folder and master do-file before adding more folders using {cmd:iefolder}.
+
+{pstd}{ul:{it:round}} folders are folders specific to a data collection round, for example, {it:Baseline}, {it:Endline},
+	{it:Follow Up} etc. (See {it:subfolder} below if your project is more complex than that.) When adding a new round, a round folder are added to the DataWork
+	and inside it the round folder structure described {browse "https://dimewiki.worldbank.org/wiki/DataWork_Survey_Round":here}. {cmd:iefolder} also
+	creates a master do-file specific for this round with globals referencing the main folders
+	in the folder structure specific to this round. Folders are created in two places, both in the DataWork folder, and in the Encrypted folder.
+
+{pstd}{ul:{it:unitofobs}} folders are folders specific to a unit of observation,
 	for example the master data set folder. Read more about master data sets and the folder structure
-	this commands sets up for you at {browse "https://dimewiki.worldbank.org/wiki/Master_Data_Set"}. A 
-	master data folder for each new unit of observation is created in two places. Both in 
-	the MasterData folder in the DataWork folder, and in the MasterKeyID folder in the encrypted folder.
+	this commands sets up for you at {browse "https://dimewiki.worldbank.org/wiki/Master_Data_Set":here}. A
+	master data folder for each new unit of observation is created in two places. Both in
+	the MasterData folder in the DataWork folder, and in the Encrypted folder.
+
+{pstd}{ul:{it:subfolder}} can be used to organize folders with a lot of data collections. For examples, instead of having only one baseline data collection, a project might have a student, a teacher, and a school data collections all in baseline. With {it:subfolder} you can, using this example, create a folder called Baseline in the DataWork folder, and when creating the rounds for student, teacher and school, you can create those round inside the Baseline folder using the option {cmd:subfolder(}{it:Baseline}{cmd:)}. When creating a subfolder, only a single folder is created in the DataWork folder and it is empty. The main master do-file is however updated with a global to this folder.
 
 {marker optslong}{title:Options}
 
-{phang}{cmdab:proj:ectfolder(}{it:dir}{cmd:)} should point to the same folder regardless 
+{phang}{cmdab:proj:ectfolder(}{it:dir}{cmd:)} should point to the same folder regardless
 	of which {it:itemtype} is created. If {it:new project} is specified, the file path should
 	point to where DataWork should be created, and if {it:new round} or {it:new project} is
-	specified, it should point to where DataWork was already created. See how the file path is 
-	the same both time when {cmd:iefolder} is called twice in Example 1 below. 
+	specified, it should point to where DataWork was already created. See how the file path is
+	the same both time when {cmd:iefolder} is called twice in Example 1 below.
 
 {phang}{cmdab:abb:reviation(}{it:string}{cmd:)} can be used to shorten the globals created
-	in the master do-files that point to the sub-folders to {it:round} folders. For example, 
-	if you create a new {it:round} called Baseline, as in Example 1, then a global to the 
-	DataSet folder called Baseline_dt will be created in the master do-file. If the 
-	abbreviation option would have been used, like in Example 2, then the global would 
+	in the master do-files that point to the sub-folders to {it:round} folders. For example,
+	if you create a new {it:round} called Baseline, as in Example 1, then a global to the
+	DataSet folder called Baseline_dt will be created in the master do-file. If the
+	abbreviation option would have been used, like in Example 2, then the global would
 	have been called BL_dt.
+
+{phang}{cmdab:sub:folder(}{it:folder}{cmd:)} creates a round folder inside the folder specified in this option. This option can only be used when creating a new round. The folder specified must have been created using {cmd:iefolder}. See example 3.
 
 {title:Examples}
 
@@ -94,16 +96,16 @@ help for {hi:iefolder}
 {pmore}{inp:iefolder new project , projectfolder("$projectFolder")}{break}
 {inp:iefolder new round baseline , projectfolder("$projectFolder")}
 
-{pstd}In the example above, in the line the first time {cmd:iefolder} is used, a folder 
-	called {hi:DataWork} is created at the location of {it:"C:\Users\Documents\DropBox\ProjectABC"}. 
-	In the line where {cmd:iefolder} used a second time, a folder for the baseline round 
-	is created inside the {hi:DataWork} folder. Note that the folder provided 
+{pstd}In the example above, in the line the first time {cmd:iefolder} is used, a folder
+	called {hi:DataWork} is created at the location of {it:"C:\Users\Documents\DropBox\ProjectABC"}.
+	In the line where {cmd:iefolder} used a second time, a folder for the baseline round
+	is created inside the {hi:DataWork} folder. Note that the folder provided
 	in {inp:projectfolder()} is the same both times.
-	
-{pstd}Both the {hi:DataWork} folder and the {hi:baseline} folder created have sub-folders 
+
+{pstd}Both the {hi:DataWork} folder and the {hi:baseline} folder created have sub-folders
 	and master do-files creating globals pointing to these.
 
-	
+
 {pstd}{hi:Example 2.}
 
 {pmore}{inp:global projectFolder "C:\Users\Documents\DropBox\ProjectABC"}
@@ -111,61 +113,82 @@ help for {hi:iefolder}
 {pmore}{inp:iefolder new project , projectfolder("$projectFolder")}{break}
 {inp:iefolder new round baseline , projectfolder("$projectFolder") abbreviation("BL")}
 
-{pstd}The example above creates the same folder structure as in Example 1, but 
-	in the globals in the master do-files the abbreviation BL is used instead of 
+{pstd}The example above creates the same folder structure as in Example 1, but
+	in the globals in the master do-files the abbreviation BL is used instead of
 	baseline. But the folders created on disk will still be called baseline.
 
-	
 {pstd} {hi:Example 3.}
 
-{pstd}The example below is meant to describe an intended workflow for a full 
+{pstd}This example shows how to use subfolders.
+
+{pmore}{inp:global projectFolder "C:\Users\Documents\DropBox\ProjectABC"}
+
+{pmore}{inp:iefolder new project , projectfolder("$projectFolder")}
+
+{pmore}{inp:iefolder new subfolder baseline , projectfolder("$projectFolder")}{break}
+{inp:iefolder new round studentBL , projectfolder("$projectFolder") subfolder("baseline")}{break}
+{inp:iefolder new round teacherBL , projectfolder("$projectFolder") subfolder("baseline")}
+
+{pstd}The code above creates a new {hi:DataWork} folder inside the folder ProjectABC. Then {hi:subfolder} is used to create a folder called baseline. Then the two baseline rounds, student and teacher, are created inside the folder baseline.
+
+{pstd}The code below shows how the endline folder can be created in the same folder. Note that the rounds need to have unique names even across subfolders, and that is why the student and teacher round have the suffix EL.
+
+{pmore}{inp:global projectFolder "C:\Users\Documents\DropBox\ProjectABC"}
+
+{pmore}{inp:iefolder new subfolder endline , projectfolder("$projectFolder")}{break}
+{inp:iefolder new round studentEL , projectfolder("$projectFolder") subfolder("endline")}{break}
+{inp:iefolder new round teacherEL , projectfolder("$projectFolder") subfolder("endline")}
+
+{pstd} {hi:Example 4.}
+
+{pstd}The example below is meant to describe an intended workflow for a full
 	life cycle of an impact evaluation. First we need to set up the {hi:DataWork} folder.
 	We do that using {it:{cmd:iefolder} new project}. Like this:
 
-{pmore}{inp:iefolder new project , projectfolder("C:\Users\Documents\DropBox\ProjectABC")}
+{pmore}{inp:iefolder new project , projectfolder("C:\DropBox\ProjectABC")}
 
-{pstd}Our first data collection will be a baseline where the unit of observation 
-	is households. We therefore need to set up folders for the unit of observation 
-	"households". In the encrypted master folder for "housholds" you can create your 
-	list over households and you have a subfolder called {it:Sampling} where you 
-	can keep do files and data with identifying infomration. We create all of that by 
+{pstd}Our first data collection will be a baseline where the unit of observation
+	is households. We therefore need to set up folders for the unit of observation
+	"households". In the encrypted master folder for "housholds" you can create your
+	list over households and you have a subfolder called {it:Sampling} where you
+	can keep do files and data with identifying infomration. We create all of that by
 	using {it:{cmd:iefolder} new untiofobs household}.	Like this:
 
-{pmore}{inp:iefolder new untiofobs household , projectfolder("C:\Users\Documents\DropBox\ProjectABC") abbreviation("BL")}
+{pmore}{inp:iefolder new untiofobs household , projectfolder("C:\DropBox\ProjectABC") abbreviation("BL")}
 
-{pstd}When we are ready to start preparing for the baseline we want to create the 
+{pstd}When we are ready to start preparing for the baseline we want to create the
 	baseline folder. We do that using {it:{cmd:iefolder} new round baseline}. Like this:
 
-{pmore}{inp:iefolder new round baseline , projectfolder("C:\Users\Documents\DropBox\ProjectABC") abbreviation("BL")}
+{pmore}{inp:iefolder new round baseline , projectfolder("C:\DropBox\ProjectABC") abbreviation("BL")}
 
 {pstd}At this point we can collect the baseline data, save the data in the folders
-	we created and write the report. Then long stretches of time might pass before 
-	we need to use the command. 
-	
+	we created and write the report. Then long stretches of time might pass before
+	we need to use the command.
+
 {pstd}Let's say that when we plan for midline we also want
-	to collect data about the villages that the households we interview in baseline 
-	live in. Then we need to create a new master folder for the unit of observation 
+	to collect data about the villages that the households we interview in baseline
+	live in. Then we need to create a new master folder for the unit of observation
 	villages. We do that using {it:{cmd:iefolder} new untiofobs village}. Like this:
 
-{pmore}{inp:iefolder new untiofobs village , projectfolder("$projectFolder")}
+{pmore}{inp:iefolder new untiofobs village , projectfolder("C:\DropBox\ProjectABC")}
 
-{pstd}Then we need to create the rounds used for the midline round for both 
-	households and for villages. Since this is separate data collection (although 
+{pstd}Then we need to create the rounds used for the midline round for both
+	households and for villages. Since this is separate data collection (although
 	they might happen at the same time). We create those folders like this:
 
-{pmore}{inp:iefolder new round midlineVillage , projectfolder("$projectFolder") abbreviation("ML")}{break}
-{inp:iefolder new round midline {space 6}     , projectfolder("$projectFolder") abbreviation("MLvill")}
+{pmore}{inp:iefolder new round midline {space 6}, projectfolder("C:\DropBox\ProjectABC") abbreviation("ML")}{break}
+{inp:iefolder new round midlineVillage, projectfolder("C:\DropBox\ProjectABC") abbreviation("MLvill")}
 
-{pstd}Finally, in the last round of data collection, we are only collecting data 
-	on households again. Since we are not collecting data on any new unit 
+{pstd}Finally, in the last round of data collection, we are only collecting data
+	on households again. Since we are not collecting data on any new unit
 	of observation, we do not need to create any new master folder.
 
-{pmore}{inp:iefolder new round endline , projectfolder("$projectFolder") abbreviation("EL")}
+{pmore}{inp:iefolder new round endline , projectfolder("C:\DropBox\ProjectABC") abbreviation("EL")}
 
 {title:Acknowledgements}
 
 {phang}I would like to acknowledge the help in testing and proofreading I received in relation to this command and help file from (in alphabetic order):{p_end}
-{pmore}Laura Costica{break}Luiza Cardoso De Andrade{break}Mrijan Rimal{break}Sakina Shibuya{break}Seungmin Lee
+{pmore}Guadalupe Bedoya{break}Laura Costica{break}Luiza Cardoso De Andrade{break}Mrijan Rimal{break}Sakina Shibuya{break}Seungmin Lee
 
 {title:Author}
 


### PR DESCRIPTION
This PR fixes issue #92 - allowing iefolder to create subfolders that rounds can be created in. 

During this update the code was simplified substantially but iefolder is still a complex command and more simplification is probably needed before this command is easily maintained.

For example, all new items are created in the same function that parse an update the project master dofile