### PR TITLE
iegitaddmd : Fixes Issue #118 and solution to name conflict with option all

### DIFF
--- a/src/ado_files/iegitaddmd.ado
+++ b/src/ado_files/iegitaddmd.ado
@@ -89,7 +89,6 @@ cap program drop   iegitaddmd
 				*Use user provided file. First test if it already exist
 			
 				cap confirm file `"`folder'`userfilename'"'
-				noi di _rc
 				if _rc == 0 & "`skip'" == "" & "`replace'" == "" {
 					
 					*File exist and neither skip or replace is used

--- a/src/help_files/iegitaddmd.sthlp
+++ b/src/help_files/iegitaddmd.sthlp
@@ -6,18 +6,21 @@ help for {hi:iegitaddmd}
 
 {title:Title}
 
-{phang}{cmdab:iegitaddmd} {hline 2} Creates a placeholder README.md file in subfolders of a GitHub repository folder, which is often needed to sync standardized folder structures.
+{phang}{cmdab:iegitaddmd} {hline 2} Creates a placeholder file in subfolders of a GitHub repository folder, which allows to commit folder structures with empty folders.
 
 {title:Syntax}
 
-{phang} {cmdab:iegitaddmd} , {cmd:folder(}{it:file_path}{cmd:)} [all]
+{phang} {cmdab:iegitaddmd} , {cmd:folder(}{it:file_path}{cmd:)} [file({help filename}) all skip replace]
 
 {marker opts}{...}
 {synoptset 18}{...}
 {synopthdr:options}
 {synoptline}
 {synopt :{cmd:folder(}{it:file_path}{cmd:)}}Specifies the folder path to the repository folder{p_end}
-{synopt :{cmd:all}}Creates one {it:README.md} file in every subfolder of {cmd:folder()}, whether empty or not{p_end}
+{synopt :{cmd:file(}{it:{help filename}}{cmd:)}}Specifies a file saved on disk that is used instead of the default file as placeholder{p_end}
+{synopt :{cmd:all}}Creates the placeholder file in every subfolder of {cmd:folder()}, whether empty or not{p_end}
+{synopt :{cmd:skip}}If option {cmd:all} is used and a folder has a file with same name as placeholder file, then nothing is done{p_end}
+{synopt :{cmd:replace}}If option {cmd:all} is used and a folder has a file with same name as placeholder file, then the file is overwritten{p_end}
 {synoptline}
 
 {marker desc}
@@ -30,22 +33,44 @@ help for {hi:iegitaddmd}
 	be empty and GitHub will not sync them, meaning that they will not be available to the full
 	team. {cmd:iegitaddmd} is a Stata adaptation of {it:Solution B} in {browse "http://bytefreaks.net/gnulinux/bash/how-to-add-automatically-all-empty-folders-in-git-repository" :this post}.
 
-{pstd}{cmd:iegitaddmd} creates a placeholder README.md file in all empty subfolders of 
-	the folder specified in {cmd:folder()}. The placeholder file may be removed as 
+{pstd}{cmd:iegitaddmd} creates a placeholder file in all empty subfolders of 
+	the folder specified in {cmd:folder()}. The default file used if no file is specified 
+	using option {cmd:file()} is called README.md, which is a name and format recognized by 
+	github.com so that the content of the file is displayed if the folder with that file is 
+	browsed on GitHub.com. The placeholder file may be removed as 
 	soon as actual files have been added to the folder. Alternatively, if the option
-	{cmd:all} is used, {cmd:iegitaddmd} will create one README.md file in each subfolder
+	{cmd:all} is used, {cmd:iegitaddmd} will create the placeholder file in each subfolder
 	of {cmd:folder()}, regardless of them being empty or not.
 
 {marker optslong}
 {title:Options}
 
-{phang}{cmd:folder(}{it:file_path}{cmd:)} is the folder path to the repository with empty folders where the file {it:README.md} will be created in each empty folder.
+{phang}{cmd:folder(}{it:file_path}{cmd:)} is the folder path to the project folder where the 
+	placeholder file will be created in each empty folder.
+	
+{phang}{cmd:file(}{it:{help filename}}{cmd:)} allows the user to specify a file saved on 
+	the computer to be used as the placeholder file	instead of the default README.md file. This 
+	allows people and organizations to write their own template placeholder files according to their own 
+	preferences. We recommend that a file of type .md (markdown) and name README.md is used as 
+	GitHub.com recognizes this name and format and will display the content of the file when someone 
+	browse to that folder on GitHub.com. But this is not a technical requirement, any file type 
+	and name can be used as placeholder file.
 
-{phang}{cmd:all} creates one {it:README.md} in every subfolder of {cmd:folder()}, whether empty or not. This allows the user to edit the {it:README.md} files and 
-	add instructions on the purpose and usage of each subfolder. It is also important when a .{it:gitignore} is used, as {cmd:iegitaddmd} will not
-	create add files to subfolders that are not empty, but only contain ignored files -- in which case the subfolder will not be synced.
+{phang}{cmd:all} creates the placeholder file in {cmd:folder()} and in every subfolder, 
+	regardless if they are empty or not. This allows the user to create a placeholder file in every 
+	folder that can be edited with documentation and instructions to the purpose and usage of 
+	each subfolder. This option can also be important when .{it:gitignore} is used, as {cmd:iegitaddmd} will not
+	create files to subfolders that only has ignored file -- in which case the folder will not 
+	be synced by GitHub.
 				 
-
+{phang}{cmd:skip} and {cmd:replace} tells {cmd:iegitaddmd} what to do if the option {cmd:all} is used
+	and if any of the folders contain a file with the same name as the placeholder file the command 
+	is trying to create. If a file with the same name as the placeholder file exist and neither of these options 
+	are used, then the command will throw an error. If {cmd:skip} is used, then nothing is done in the 
+	folder where the file with the same name exists and the command proceeds to the next folder. 
+	If {cmd:replace} is used then the file with the same name is overwritten with the new placeholder
+	file before the command proceeds to the next folder.
+				 			 
 {title:Example}
 
 {pstd}{inp:global github_folder "C:\Users\JohnSmith\Documents\GitHub\ProjectA"}{break}{inp:iegitaddmd , folder({it:"$github_folder"})}

--- a/src/help_files/iegitaddmd.sthlp
+++ b/src/help_files/iegitaddmd.sthlp
@@ -6,7 +6,7 @@ help for {hi:iegitaddmd}
 
 {title:Title}
 
-{phang}{cmdab:iegitaddmd} {hline 2} Creates a placeholder file in subfolders of a GitHub repository folder, which allows to commit folder structures with empty folders.
+{phang}{cmdab:iegitaddmd} {hline 2} Creates a placeholder file in subfolders of a GitHub repository folder, which allows committing folder structures with empty folders.
 
 {title:Syntax}
 


### PR DESCRIPTION
This PR provides a fix to issue #188 that was an feature request to add an option that allows the user to use his/her own file as placeholder file instead of the default _README.md_ file. 

While implementing this feature I also added the option **skip** and **replace** that tells iegitaddmd what to do if the option _all_ was used and a file with the same name as the placeholder file already exists. **skip** tells the command to do nothing in that folder, and **replace** overwrites the existing file with the new placeholder.

Up until now the command always behaved like in the **skip** if option _all_ was used and there were a name conflict, but now it is up to the user how the command will behave. If there is a name conflict and neither **skip** nor **replace** is used, then the command now throws an error instead of just skipping.