### PR TITLE
Issue 124 ietoolkit command

### DIFF
--- a/src/ado_files/iefolder.ado
+++ b/src/ado_files/iefolder.ado
@@ -889,12 +889,18 @@ cap program drop 	mdofle_p0
 		writeDevisor `subHandle' 0 End_StandardSettings
 		
 		file write  `subHandle' 	///							
-			_col(8)"*Install all packages that this project requires:" _n ///
-			_col(8)"ssc install ietoolkit, replace" _n ///
+			_col(4)"*Install all packages that this project requires:" _n ///			
+			_col(4)"local user_commands ietoolkit" _col(40) "//Fill this list will all commands this project requires" _n ///	
+			_col(4)"foreach command of local user_commands {" _n ///	
+			_col(8)		"cap which " _char(96) "command'" _n ///	
+			_col(8)		"if _rc == 111 {" _n ///	
+			_col(12)		"cap ssc install " _char(96) "command'" _n ///	
+			_col(8)		"}" _n ///	
+			_col(4)"}" _n ///	
 			_n	 ///
-			_col(8)"*Standardize settings accross users" _n ///
-			_col(8)"ieboilstart, version(12.1)" _col(40) "//Set the version number to the oldest version used by anyone in the project team" _n ///
-			_col(8) _char(96)"r(version)'" 		_col(40) "//This line is needed to actually set the version from the command above" _n
+			_col(4)"*Standardize settings accross users" _n ///
+			_col(4)"ieboilstart, version(12.1)" _col(40) "//Set the version number to the oldest version used by anyone in the project team" _n ///
+			_col(4) _char(96)"r(version)'" 		_col(40) "//This line is needed to actually set the version from the command above" _n
 			
 		
 end

--- a/src/ado_files/ietoolkit.ado
+++ b/src/ado_files/ietoolkit.ado
@@ -25,8 +25,8 @@ program ietoolkit, rclass
 	**********************/	
 	
 	* Prepare returned locals
-	return local diffvars 	`"`difference'"'
-	return scalar nummatch	= `:list sizeof match'
+	return local 	versiondate "`versionDate'"
+	return scalar 	version		= `version'
 	
 	* Display output
 	noi di ""

--- a/src/ado_files/ietoolkit.ado
+++ b/src/ado_files/ietoolkit.ado
@@ -1,0 +1,36 @@
+*! version 5.4 15DEC2017  DIME Analytics lcardosodeandrad@worldbank.org
+		
+capture program drop ietoolkit, rclass
+program ietoolkit, rclass
+	
+	* UPDATE THESE LOCALS FOR EACH NEW VERSION PUBLISHED
+	local version "5.4"
+	local versionDate "15DEC2017"
+	
+	
+	syntax [anything]
+	
+	/********************** 
+		Error messages 
+	**********************/
+	
+	* Make sure that no arguments were passed	
+	if "`anything'" != "" {
+		noi di as error "This command does not take any arguments, write only {it:ietoolkit}"
+		error 198
+	}
+	
+	/********************** 
+		Output 
+	**********************/	
+	
+	* Prepare returned locals
+	return local diffvars 	`"`difference'"'
+	return scalar nummatch	= `:list sizeof match'
+	
+	* Display output
+	noi di ""
+	noi di _col(4) "This version of ietoolkit installed is version " _col(54)"`version'"
+	noi di _col(4) "This version of ietoolkit was released on " _col(54)"`versionDate'"
+	
+end

--- a/src/ado_files/ietoolkit.ado
+++ b/src/ado_files/ietoolkit.ado
@@ -1,6 +1,6 @@
 *! version 5.4 15DEC2017  DIME Analytics lcardosodeandrad@worldbank.org
 		
-capture program drop ietoolkit, rclass
+capture program drop ietoolkit
 program ietoolkit, rclass
 	
 	* UPDATE THESE LOCALS FOR EACH NEW VERSION PUBLISHED

--- a/src/help_files/ietoolkit.sthlp
+++ b/src/help_files/ietoolkit.sthlp
@@ -1,30 +1,30 @@
 {smcl}
 {* 15 Dec 2017}{...}
 {hline}
-help for {hi:iegraph}
+help for {hi:ietoolkit}
 {hline}
 
 {title:Title}
 
 {phang}{cmdab:ietoolkit} {hline 2} Returns information on the version of ietoolkit installed
 
-{phang}For a more descriptive discussion on the intended usage and work flow of this 
+{phang}For a more descriptive discussion on the intended usage and work flow of this
 command please see the {browse "https://dimewiki.worldbank.org/wiki/Ietoolkit":DIME Wiki}.
 
 {title:Syntax}
 
 {phang}
-{cmdab:ietoolkit} 
+{cmdab:ietoolkit}
 
-{pstd}Note that this command takes no arguements at all.{p_end}
+{pstd}Note that this command takes no arguments at all.{p_end}
 
 {marker desc}
 {title:Description}
 
-{pstd}{cmdab:iegraph} This command returns the version of ietoolkit installed. It 
-	can be used in the beginning of a Master Do-file that is intended to be used 
-	by mutliple users to programmatically test if ietoolkit is not installed for 
-	the user and therefore need to be installed, or if the version the user has 
+{pstd}{cmdab:iegraph} This command returns the version of ietoolkit installed. It
+	can be used in the beginning of a Master Do-file that is intended to be used
+	by multiple users to programmatically test if ietoolkit is not installed for
+	the user and therefore need to be installed, or if the version the user has
 	installed is too old and needs to be upgraded.
 
 {marker optslong}
@@ -35,12 +35,12 @@ command please see the {browse "https://dimewiki.worldbank.org/wiki/Ietoolkit":D
 {marker example}
 {title:Examples}
 
-{pstd}The code below is an example code that can be added to the top of any dofile. 
-	the example code first test if the command is installed, and install it if not. If it is 
-	installed, it test if the version is less than version 5.0. If it is, it 
+{pstd}The code below is an example code that can be added to the top of any do-file.
+	the example code first test if the command is installed, and install it if not. If it is
+	installed, it test if the version is less than version 5.0. If it is, it
 	replaces the ietoolkit file with the latest version. In your code you can skip
-	the second part if you are not sure which version is required. But you should 
-	always have the first part testing that {inp:r(version)} has a value before using 
+	the second part if you are not sure which version is required. But you should
+	always have the first part testing that {inp:r(version)} has a value before using
 	it in less than or greater than expressions.
 
 {inp}    cap ietoolkit
@@ -64,7 +64,7 @@ command please see the {browse "https://dimewiki.worldbank.org/wiki/Ietoolkit":D
 {phang}Kristoffer Bjarkefur, The World Bank, DECIE
 
 {phang}Please send bug-reports, suggestions and requests for clarifications
-		 writing "ietoolkit ietoolkit" in the subject line to the email address 
+		 writing "ietoolkit ietoolkit" in the subject line to the email address
 		 found {browse "https://github.com/worldbank/ietoolkit":here}
 
 {phang}You can also see the code, make comments to the code, see the version

--- a/src/help_files/ietoolkit.sthlp
+++ b/src/help_files/ietoolkit.sthlp
@@ -1,0 +1,73 @@
+{smcl}
+{* 15 Dec 2017}{...}
+{hline}
+help for {hi:iegraph}
+{hline}
+
+{title:Title}
+
+{phang}{cmdab:ietoolkit} {hline 2} Returns information on the version of ietoolkit installed
+
+{phang}For a more descriptive discussion on the intended usage and work flow of this 
+command please see the {browse "https://dimewiki.worldbank.org/wiki/Ietoolkit":DIME Wiki}.
+
+{title:Syntax}
+
+{phang}
+{cmdab:ietoolkit} 
+
+{pstd}Note that this command takes no arguements at all.{p_end}
+
+{marker desc}
+{title:Description}
+
+{pstd}{cmdab:iegraph} This command returns the version of ietoolkit installed. It 
+	can be used in the beginning of a Master Do-file that is intended to be used 
+	by mutliple users to programmatically test if ietoolkit is not installed for 
+	the user and therefore need to be installed, or if the version the user has 
+	installed is too old and needs to be upgraded.
+
+{marker optslong}
+{title:Options}
+
+{phang}This command does not take any options.
+
+{marker example}
+{title:Examples}
+
+{pstd}The code below is an example code that can be added to the top of any dofile. 
+	the example code first test if the command is installed, and install it if not. If it is 
+	installed, it test if the version is less than version 5.0. If it is, it 
+	replaces the ietoolkit file with the latest version. In your code you can skip
+	the second part if you are not sure which version is required. But you should 
+	always have the first part testing that {inp:r(version)} has a value before using 
+	it in less than or greater than expressions.
+
+{inp}    cap ietoolkit
+{inp}    if "`r(version)'" == "" {
+{inp}      *ietoolkit not installed, install it
+{inp}      ssc install ietoolkit
+{inp}    }
+{inp}    else if `r(version)' < 5.0 {
+{inp}      ietoolkit version too old, install the latest version
+{inp}      ssc install ietoolkit , replace
+{inp}    }{text}
+
+{title:Acknowledgements}
+
+{phang}We would like to acknowledge the help in testing and proofreading we received
+ in relation to this command and help file from (in alphabetic order):{p_end}
+{pmore}Luiza Cardoso De Andrade{break}Seungmin Lee{break}
+
+{title:Authors}
+
+{phang}Kristoffer Bjarkefur, The World Bank, DECIE
+
+{phang}Please send bug-reports, suggestions and requests for clarifications
+		 writing "ietoolkit ietoolkit" in the subject line to the email address 
+		 found {browse "https://github.com/worldbank/ietoolkit":here}
+
+{phang}You can also see the code, make comments to the code, see the version
+		 history of the code, and submit additions or edits to the code through
+		 the github repository of ietoolkit:{break}
+		 {browse "https://github.com/worldbank/ietoolkit"}


### PR DESCRIPTION
Create a command with the same name as the package that is something that can be used when programmatically check if the package is installed, and if not install it.

The command itself only return which version of ietoolkit that is installed. Someone might come up with a good usage of that at some point.