### PR TITLE
ieduplicates: fix typo in error message

### DIFF
--- a/src/ado_files/ieduplicates.ado
+++ b/src/ado_files/ieduplicates.ado
@@ -167,7 +167,7 @@
 				*Test that the ID variable is in the imported report
 				if `:list idvar in existingExcelVars' == 0 {
 
-					noi display as error "{phang}The ID variable `idvar' does not exist in the previously exported Excle file. If you renamed the ID variable you need to rename it manually in the Excel report or start a new Excel report by renaming or moving the original report, then run the command again and create a new file and manually copy any corrections from the old file to the new. If you changed the ID varaible you need to start with a new report.{p_end}"
+					noi display as error "{phang}The ID variable `idvar' does not exist in the previously exported Excle file. If you renamed the ID variable you need to rename it manually in the Excel report or start a new Excel report by renaming or moving the original report, then run the command again and create a new file and manually copy any corrections from the old file to the new. If you changed the ID variable you need to start with a new report.{p_end}"
 					noi di ""
 					error 111
 					exit
@@ -615,7 +615,7 @@
 						levelsof newID if missing(real(newID)), local(NaN_values) clean
 
 						* Output error message
-						di as error "{phang}The ID varaible `idvar' is numeric but newID has thes non-numeric values: `NaN_values'. Update newID to only contain numeric values or see option tostringok.{p_end}"
+						di as error "{phang}The ID variable `idvar' is numeric but newID has these non-numeric values: `NaN_values'. Update newID to only contain numeric values or see option tostringok.{p_end}"
 						error 109
 						exit
 					}


### PR DESCRIPTION
Misspelling of `variable` and `these` in output error messages related to ID var.