### PR TITLE
iebaltab: Add `SETtest` option

### DIFF
--- a/src/ado_files/iebaltab.ado
+++ b/src/ado_files/iebaltab.ado
@@ -44,6 +44,7 @@
 				NOTtest														///
 				NORMDiff													///
 				PTtest														///
+				SETtest														///
 				PFtest														///
 				FEQTest														///
 				PBoth														///
@@ -217,6 +218,10 @@ qui {
 		*Is option pttest() used:
 		if "`pttest'" 			== "" local PTTEST_USED = 0
 		if "`pttest'" 			!= "" local PTTEST_USED = 1
+		
+		*Is option settest() used:
+		if "`settest'" 			== "" local SETTEST_USED = 0 
+		if "`settest'" 			!= "" local SETTEST_USED = 1 
 
 		*Is option pftest() used:
 		if "`pftest'" 			== "" local PFTEST_USED = 0
@@ -518,6 +523,13 @@ qui {
 			noi display as error "{phang}Option totallabel() may only be used together with the option total"
 			error 197
 		}
+	
+		if `SETTEST_USED' & `PTTEST_USED' {
+			
+			*Error for settest() and pttest() incorrectly applied together
+			noi display as error "{phang}Option settest may not be used in combination with the option pttest"
+			error 197
+		}	
 
 
 	** Stats Options
@@ -1808,6 +1820,12 @@ qui {
 						*Perform the t-test and store p-value in pttest
 						test `tempvar_thisGroupInPair'
 						local pttest = r(p)
+					
+						if `SETTEST_USED' {
+							local diffse = _se[`tempvar_thisGroupInPair']
+							local diffse : display `diformat' `diffse'
+							local diffse = trim("`diffse'")
+						}
 
 
 						*If p-test option is used
@@ -1834,8 +1852,9 @@ qui {
 						local tableRowUp 	`" `tableRowUp' _tab "`ttest_output'" "'
 						local tableRowDo 	`" `tableRowDo' _tab " " "'
 
-						local texRow	`" `texRow' " & `ttest_output'" "'
-					}
+						if `PTTEST_USED' | !`SETTEST_USED' local texRow	`" `texRow' " & `ttest_output'" "'
+						else local texRow	`" `texRow' " & \begin{tabular}[t]{@{}c@{}} `ttest_output' \\ (`diffse') \end{tabular}" "'
+				}
 				}
 			}
 


### PR DESCRIPTION
In light of journals like the AER disallowing the use of significance stars, one might want to display the difference column(s) as mean difference **with its appropriate standard error** to allow readers their own inference. I've implemented this. Specifying the option `SETtest` adds standard errors in parantheses. This option does not work in combination with PTtest. I've done a reasonable amount of testing, but of course the use of this code is as always at your own peril.