### PR TITLE
Fixed a typo in iedropone.sthlp and suggested some changes in notations in iebaltab.ado

### DIFF
--- a/src/ado_files/iebaltab.ado
+++ b/src/ado_files/iebaltab.ado
@@ -1291,10 +1291,10 @@ qui {
 			if `testPairCount' > 0 {
 
 				if `TTEST_USED' {
-					local texrow1 	`" `texrow1' & \multicolumn{`testPairCount'}{c}{T-test} "'
+					local texrow1 	`" `texrow1' & \multicolumn{`testPairCount'}{c}{$ t$-test} "'
 
 					if `PTTEST_USED' == 1 {
-						local texrow2 `"`texrow2' & \multicolumn{`testPairCount'}{c}{P-value} "'
+						local texrow2 `"`texrow2' & \multicolumn{`testPairCount'}{c}{$ p$-value} "'
 					}
 					else {
 						local texrow2 `"`texrow2' & \multicolumn{`testPairCount'}{c}{Difference} "'
@@ -1314,11 +1314,11 @@ qui {
 
 		if `FEQTEST_USED' {
 
-			local titlerow1 `"`titlerow1' _tab "F-test""'
+			local titlerow1 `"`titlerow1' _tab "$ F$-test""'
 			local titlerow2 `"`titlerow2' _tab "for joint""'
 			local titlerow3 `"`titlerow3' _tab "orthogonality""'
 
-			local texrow1 	`" `texrow1' & \multicolumn{1}{c}{F-test} "'
+			local texrow1 	`" `texrow1' & \multicolumn{1}{c}{$ F$-test} "'
 			local texrow2 	`" `texrow2' & \multicolumn{1}{c}{for joint}"'
 			local texrow3 	`" `texrow3' & \multicolumn{1}{c}{orthogonality}"'
 		}
@@ -2402,17 +2402,17 @@ qui {
 	local stars_note	"***, **, and * indicate significance at the `p3star_percent', `p2star_percent', and `p1star_percent' percent critical level. "
 
 	if `PTTEST_USED' == 1 {
-		local ttest_note "The value displayed for t-tests are p-values. "
+		local ttest_note "The value displayed for $ t$-tests are $ p$-values. "
 	}
 	else {
-		local ttest_note "The value displayed for t-tests are the differences in the means across the groups. "
+		local ttest_note "The value displayed for $ t$-tests are the differences in the means across the groups. "
 	}
 
 	if `PFTEST_USED' == 1 {
-		local ftest_note "The value displayed for F-tests are p-values. "
+		local ftest_note "The value displayed for $ F$-tests are $ p$-values. "
 	}
 	else {
-		local ftest_note "The value displayed for F-tests are the F-statistics. "
+		local ftest_note "The value displayed for $ F$-tests are the $ F$-statistics. "
 	}
 
 	if `VCE_USED' == 1 {

--- a/src/ado_files/iegitaddmd.ado
+++ b/src/ado_files/iegitaddmd.ado
@@ -350,7 +350,7 @@ qui {
 end
 
 *Recursively call parent folders in folderpath needed to be created until
-* folder found that already exist, then creaet all subfolders.
+* folder found that already exist, then create all subfolders.
 cap program drop rmkdir
 program define   rmkdir, rclass
 

--- a/src/help_files/iedropone.sthlp
+++ b/src/help_files/iedropone.sthlp
@@ -120,7 +120,7 @@ command please see the {browse "https://dimewiki.worldbank.org/wiki/Iedropone":D
 
 {pstd} {hi:Example 4.}
 
-{pmore}{inp:iedropone if village == 100, mvar(household_head) mvar(`" "Bob Smith" "Ann Davitt" "Blessing Johnson" "')}
+{pmore}{inp:iedropone if village == 100, mvar(household_head) mval(`" "Bob Smith" "Ann Davitt" "Blessing Johnson" "')}
 
 {pmore}If the values in {cmd:mvar()} are strings with empty spaces then then each
 	value have to be enclosed in double quotes and the full list needs to start


### PR DESCRIPTION
I prefer to use italic letters for t-test, p-value, and F-test (like $t$-value in latex), but this is just my preference. But I think "T-test" in iebaltab needs to be "t-test" at least. 