### PR TITLE
ieboilstart : add adopath option

### DIFF
--- a/run/ieboilstart.do
+++ b/run/ieboilstart.do
@@ -1,0 +1,35 @@
+
+
+    global rieboil "${runoutput}/ieboilstart"
+    
+    //cap which iefieldkit
+    //if _rc == 111 ssc install iefieldkit
+    
+     * Load the command from file and utils
+	qui	do "${ietoolkit_clone}/src/ado_files/ieboilstart.ado"
+    qui do "${ietoolkit_clone}/src/ado_files/ietoolkit.ado"
+	   
+	* Set PERSONAL path
+	ieboilstart , version(13.1) adopath("${rieboil}/ado1")
+	`r(version)'
+    
+    *Test mock command in this ado path
+    ado1
+    
+    iefieldkit
+    
+
+    * Reload commands
+	qui	do "${ietoolkit_clone}/src/ado_files/ieboilstart.ado"
+    qui do "${ietoolkit_clone}/src/ado_files/ietoolkit.ado"
+    
+    * Set PLUS path
+	ieboilstart , version(13.1) adopath("${rieboil}/ado2", strict)
+	`r(version)'
+    
+    *Test mock command in this ado path
+    ado2
+    
+    * Test that otherwise instaleld commands are not accessible after "strict"
+    cap iefieldkit
+    assert _rc == 199

--- a/run/output/ieboilstart/ado1/ado1.ado
+++ b/run/output/ieboilstart/ado1/ado1.ado
@@ -1,0 +1,4 @@
+capture program drop ado1
+		    program      ado1 , rclass
+        noi di "Ado1 ran successfully"
+end

--- a/run/output/ieboilstart/ado2/ado2.ado
+++ b/run/output/ieboilstart/ado2/ado2.ado
@@ -1,0 +1,4 @@
+capture program drop ado2
+		    program      ado2 , rclass
+        noi di "Ado2 ran successfully"
+end

--- a/src/ado_files/ieboilstart.ado
+++ b/src/ado_files/ieboilstart.ado
@@ -56,6 +56,48 @@
 
     ****************************************************************************
 		***************************************************************************/
+
+    if !missing(`"`adopath'"') {
+
+      * split out path and ado sub option
+      gettoken apath aoption : adopath , parse(",")
+      local apath   = trim("`apath'")
+      local aoption = trim(subinstr("`aoption'",",","",1))
+
+      if !missing("`aoption'") & "`aoption'" != "strict" {
+        noi di as error `"{phang}The suboption [`aoption'] in the option [`adopath'] is not a valid suboption. See help file for more details.{p_end}"'
+        error 198
+      }
+
+      * Test if folder exists
+      mata : st_numscalar("r(dirExist)", direxists("`apath'"))
+      if (`r(dirExist)' == 0) {
+        noi di as error `"{phang}The folder path [`apath'] in option [`adopath'] does not exist.{p_end}"'
+        error 198
+      }
+
+      * Set adopath depending on if strict was used
+      if "`aoption'" == "strict" {
+        * If strict is used, the replace plus
+        sysdir set  PLUS `"`apath'"'
+        adopath ++  PLUS
+        adopath ++  BASE
+
+        * Remove all adopaths other than
+        local morepaths 1
+        while (`morepaths' == 1) {
+          capture adopath - 3
+          if _rc local morepaths 0
+        }
+      }
+      else {
+        * Set PERSONAL path to ado path
+        sysdir set  PERSONAL `"`apath'"'
+        adopath ++  PERSONAL
+        adopath ++  BASE
+      }
+    }
+
     /***************************************************************************
     ****************************************************************************
 

--- a/src/ado_files/ieboilstart.ado
+++ b/src/ado_files/ieboilstart.ado
@@ -106,7 +106,7 @@
           if _rc local morepaths 0
         }
 
-        local aoutput `"`aoutput'PLUS adopath was set to [`apath']. All other adopaths (apart from BASE) were removed so only programs and ado-files in this PLUS folder is accessible to your code."'
+        local aoutput `"`aoutput'PLUS adopath was set to [`apath']. All adopaths other than this and BASE have been removed. Only programs and ado-files in this PLUS folder are accessible to Stata until the end of this session."'
       }
       else {
         * Set PERSONAL path to ado path
@@ -114,10 +114,10 @@
         adopath ++  PERSONAL
         adopath ++  BASE
 
-        local aoutput `"`aoutput'PERSONAL adopath was set to [`apath']. Any other adopath is still availible."'
+        local aoutput `"`aoutput'PERSONAL adopath was set to [`apath']. All other prior adopath locations remain available."'
       }
 
-      local aoutput `"`aoutput' Run {stata adopath} to see your current setting. These settings are restores next time you restart Stata.{p_end}"'
+      local aoutput `"`aoutput' Do {stata adopath} to see your current setting. These settings will be restored next time you restart Stata.{p_end}"'
     }
 
     /***************************************************************************
@@ -146,7 +146,7 @@
     *Setting maxvar requires a cleared memory. Therefore
     *maxvar() and noclear cannot be used at the same time.
     if "`maxvar'" != "" & "`clear'" != "" {
-      di as error "{phang}It is not possible to set allowed maximum numbers of variables without clearing the data. noclear and maxvar() can therefore not be specified at the same time{p_end}"
+      di as error "{phang}It is not possible to set the maximum numbers of variables without clearing the data. Therefore noclear and maxvar() cannot be specified at the same time.{p_end}"
       di ""
       error 198
       exit

--- a/src/ado_files/ieboilstart.ado
+++ b/src/ado_files/ieboilstart.ado
@@ -1,11 +1,11 @@
 *! version 6.4 11JAN2022 DIME Analytics dimeanalytics@worldbank.org
 
-	capture program drop ieboilstart
-	program ieboilstart , rclass
+  capture program drop ieboilstart
+  program ieboilstart , rclass
 
-	qui {
+  qui {
 
-		syntax ,                      ///
+    syntax ,                      ///
       /* Required options */      ///
       Versionnumber(string)       ///
       [                           ///
@@ -22,7 +22,7 @@
       Custom(string)              ///
       ]
 
-		version 12
+    version 12
 
     /***************************************************************************
       Handle deprecated options
@@ -37,39 +37,39 @@
       error 198
     }
 
-		/***************************************************************************
+    /***************************************************************************
     ****************************************************************************
 
-			STATA VERSION SECTION
+      STATA VERSION SECTION
 
     ****************************************************************************
-		***************************************************************************/
+    ***************************************************************************/
 
     * Get target versions from ietoolkit command
-  	ietoolkit
-  	local valid_stata_versions "`r(stata_target_versions)'"
+    ietoolkit
+    local valid_stata_versions "`r(stata_target_versions)'"
 
     * Test that the version passed in the options versionnumber() is valid
-		if `:list versionnumber in valid_stata_versions' == 0 {
-			di as error "{phang}The Stata version number provided in {opt versionumber(`versionnumber')} is not valid or not allowed. The Stata versions currently allowed in this command are:{break}`valid_stata_versions'{p_end}"
-			di ""
-			error 198
-			exit
-		}
+    if `:list versionnumber in valid_stata_versions' == 0 {
+      di as error "{phang}The Stata version number provided in {opt versionumber(`versionnumber')} is not valid or not allowed. The Stata versions currently allowed in this command are:{break}`valid_stata_versions'{p_end}"
+      di ""
+      error 198
+      exit
+    }
 
-		*Return the value
-		return local version "version `versionnumber'"
+    *Return the value
+    return local version "version `versionnumber'"
 
-		*Set the version specfied in the command
-		version `versionnumber'
+    *Set the version specfied in the command
+    version `versionnumber'
 
     /***************************************************************************
     ****************************************************************************
 
-			ADO PATH SECTION
+      ADO PATH SECTION
 
     ****************************************************************************
-		***************************************************************************/
+    ***************************************************************************/
 
     if !missing(`"`adopath'"') {
 
@@ -123,177 +123,175 @@
     /***************************************************************************
     ****************************************************************************
 
-			HARMONIZE SETTINGS OPTION
+      HARMONIZE SETTINGS OPTION
 
     ****************************************************************************
-		***************************************************************************/
+    ***************************************************************************/
+
+    /*********************************
+      Check settings related to older versions and Stata IC
+    *********************************/
+
+    *Test that maxvar is not set in combination when using Stata IC
+    if   !(c(MP) == 1 | c(SE) == 1) & "`maxvar'" != "" {
+      di as error "{phang}In Stata IC the maximum number of variables allowed is fixed at 2,047 and maxvar() is therefore not allowed.{p_end}"
+      error 198
+    }
+
+    /*********************************
+      Check input for maxvar and matsize if specified, otherwise set
+      maximum value allowed.
+    *********************************/
+
+    *Setting maxvar requires a cleared memory. Therefore
+    *maxvar() and noclear cannot be used at the same time.
+    if "`maxvar'" != "" & "`clear'" != "" {
+      di as error "{phang}It is not possible to set allowed maximum numbers of variables without clearing the data. noclear and maxvar() can therefore not be specified at the same time{p_end}"
+      di ""
+      error 198
+      exit
+    }
+
+    foreach maxlocal in maxvar matsize {
+      *Set locals with the max and min values fox maxvar and matsize
+      if "`maxlocal'" == "maxvar" {
+        *Stata 15 MP has a higher maximum number of maxvar
+        if c(stata_version) >= 15 & c(MP) == 1 local max 120000
+        *For Stata 15 SE and MP and SE for all lower versions
+        else local max 32767
+        local min 2048
+      }
+      if "`maxlocal'" == "matsize" {
+        local max 11000
+        local min 10
+      }
+
+      *Test if user set a value for this value
+      if "``maxlocal''" != "" {
+        *If user specified a value, test that it is between the min and the max
+        if !(``maxlocal'' >= `min' & ``maxlocal'' <= `max') {
+          di as error "{phang}`maxlocal' must be between `min' and `max' (inclusive) if you are using Stata SE or Stata MP. You entered ``maxlocal''.{p_end}"
+          di ""
+          *Throw appropriate error if below or above error
+          if ``maxlocal'' < `min' error 910
+          if ``maxlocal'' > `max' error 912
+          exit
+        }
+      }
+
+      *User did not specify value, use ieboilstart's defaults:
+      else {
+        *Set maxvar to max value allowed as this is often an issue when working with large survey data
+        if "`maxlocal'" == "maxvar" local `maxlocal' `max'
+        *Set to the default as the maximum is rarely requered.
+        if "`maxlocal'" == "matsize" local `maxlocal' 400
+      }
+    }
+
+    /*********************************
+      Handle general settings options
+    *********************************/
+
+    **Default is that these values are set as default values so that
+    * these are the default values each time Stata starts.
+    if "`nopermanently'" == "" {
+      local permanently     " , permanently"
+      local permanently_col   "{col 28}, permanently"
+    }
+    else {
+      local permanently     ""
+      local permanently_col ""
+    }
+
+    /*********************************
+      Harmonize settings
+    *********************************/
+
+    local setDispLocal "{col 5}{ul:Settings set by this command:}"
+
+    *Set basic memory limits
+    if "`clear'" == "" {
+      *Setting
+      clear all
+      local setDispLocal "`setDispLocal'{break}{col 5}clear all"
+      **Setting maxvar not allowed in Stata IC.
+      if   (c(MP) == 1 | c(SE) == 1) {
+        *Setting
+        set maxvar `maxvar' `permanently'
+        local setDispLocal "`setDispLocal'{break}{col 5}set maxvar {col 22}`maxvar'`permanently_col'"
+      }
+    }
+
+    *Setting
+    set matsize `matsize' `permanently'
+    local setDispLocal "`setDispLocal'{break}{col 5}set matsize {col 22}`matsize'`permanently_col'"
+
+    ****************
+    *Memory  settings
+
+    *Setting
+    set niceness 5  `permanently'
+    local setDispLocal "`setDispLocal'{break}{col 5}set niceness{col 22}5`permanently_col'"
+
+    *These settings cannot be modified with data in memory
+    if "`clear'" == "" {
+
+      *Settings
+      set min_memory 0  `permanently'
+      set max_memory .  `permanently'
+      local setDispLocal "`setDispLocal'{break}{col 5}set min_memory {col 22}0`permanently_col'{break}{col 5}set max_memory {col 22}.`permanently_col'"
+
+      *Set segment size to the largest value allowed by the operative system
+      if c(bit) == 64 {
+        set segmentsize  32m  `permanently'
+        local setDispLocal "`setDispLocal'{break}{col 5}set segmentsize  {col 22}32m`permanently_col'"
+      }
+      else {
+        set segmentsize  16m  `permanently'
+        local setDispLocal "`setDispLocal'{break}{col 5}set segmentsize  {col 22}16m`permanently_col'"
+      }
+    }
 
 
-		/*********************************
-			Check settings related to older versions and Stata IC
-		*********************************/
+    *********************
+    *Set simple settings
 
-		*Test that maxvar is not set in combination when using Stata IC
-		if 	!(c(MP) == 1 | c(SE) == 1) & "`maxvar'" != "" {
-			di as error "{phang}In Stata IC the maximum number of variables allowed is fixed at 2,047 and maxvar() is therefore not allowed.{p_end}"
-			error 198
-		}
+    set more off `permanently'
+    local setDispLocal "`setDispLocal'{break}{col 5}set more {col 22}off`permanently_col'"
 
+    pause on
+    local setDispLocal "`setDispLocal'{break}{col 5}pause {col 22}on"
 
-		/*********************************
-			Check input for maxvar and matsize if specified, otherwise set
-			maximum value allowed.
-		*********************************/
+    set varabbrev off `permanently'
+    local setDispLocal "`setDispLocal'{break}{col 5}set varabbrev {col 22}off`permanently_col'"
 
-		*Setting maxvar requires a cleared memory. Therefore
-		*maxvar() and noclear cannot be used at the same time.
-		if "`maxvar'" != "" & "`clear'" != "" {
-			di as error "{phang}It is not possible to set allowed maximum numbers of variables without clearing the data. noclear and maxvar() can therefore not be specified at the same time{p_end}"
-			di ""
-			error 198
-			exit
-		}
-
-		foreach maxlocal in maxvar matsize {
-			*Set locals with the max and min values fox maxvar and matsize
-			if "`maxlocal'" == "maxvar" {
-				*Stata 15 MP has a higher maximum number of maxvar
-				if c(stata_version) >= 15 & c(MP) == 1 local max 120000
-				*For Stata 15 SE and MP and SE for all lower versions
-				else local max 32767
-				local min 2048
-			}
-			if "`maxlocal'" == "matsize" {
-				local max 11000
-				local min 10
-			}
-
-			*Test if user set a value for this value
-			if "``maxlocal''" != "" {
-				*If user specified a value, test that it is between the min and the max
-				if !(``maxlocal'' >= `min' & ``maxlocal'' <= `max') {
-					di as error "{phang}`maxlocal' must be between `min' and `max' (inclusive) if you are using Stata SE or Stata MP. You entered ``maxlocal''.{p_end}"
-					di ""
-					*Throw appropriate error if below or above error
-					if ``maxlocal'' < `min' error 910
-					if ``maxlocal'' > `max' error 912
-					exit
-				}
-			}
-
-			*User did not specify value, use ieboilstart's defaults:
-			else {
-				*Set maxvar to max value allowed as this is often an issue when working with large survey data
-				if "`maxlocal'" == "maxvar" local `maxlocal' `max'
-				*Set to the default as the maximum is rarely requered.
-				if "`maxlocal'" == "matsize" local `maxlocal' 400
-			}
-		}
-
-		/*********************************
-			Handle general settings options
-		*********************************/
-
-		**Default is that these values are set as default values so that
-		* these are the default values each time Stata starts.
-		if "`nopermanently'" == "" {
-			local permanently 		" , permanently"
-			local permanently_col 	"{col 28}, permanently"
-		}
-		else {
-			local permanently     ""
-			local permanently_col ""
-		}
-
-		/*********************************
-			Harmonize settings
-		*********************************/
-
-		local setDispLocal "{col 5}{ul:Settings set by this command:}"
-
-		*Set basic memory limits
-		if "`clear'" == "" {
-			*Setting
-			clear all
-			local setDispLocal "`setDispLocal'{break}{col 5}clear all"
-			**Setting maxvar not allowed in Stata IC.
-			if 	(c(MP) == 1 | c(SE) == 1) {
-				*Setting
-				set maxvar `maxvar' `permanently'
-				local setDispLocal "`setDispLocal'{break}{col 5}set maxvar {col 22}`maxvar'`permanently_col'"
-			}
-		}
-
-		*Setting
-		set matsize `matsize' `permanently'
-		local setDispLocal "`setDispLocal'{break}{col 5}set matsize {col 22}`matsize'`permanently_col'"
-
-		****************
-		*Memory	settings
-
-		*Setting
-		set niceness 5  `permanently'
-		local setDispLocal "`setDispLocal'{break}{col 5}set niceness{col 22}5`permanently_col'"
-
-		*These settings cannot be modified with data in memory
-		if "`clear'" == "" {
-
-			*Settings
-			set min_memory 0  `permanently'
-			set max_memory .  `permanently'
-			local setDispLocal "`setDispLocal'{break}{col 5}set min_memory {col 22}0`permanently_col'{break}{col 5}set max_memory {col 22}.`permanently_col'"
-
-			*Set segment size to the largest value allowed by the operative system
-			if c(bit) == 64 {
-				set segmentsize	32m  `permanently'
-				local setDispLocal "`setDispLocal'{break}{col 5}set segmentsize	{col 22}32m`permanently_col'"
-			}
-			else {
-				set segmentsize	16m  `permanently'
-				local setDispLocal "`setDispLocal'{break}{col 5}set segmentsize	{col 22}16m`permanently_col'"
-			}
-		}
-
-
-		*********************
-		*Set simple settings
-
-		set more off `permanently'
-		local setDispLocal "`setDispLocal'{break}{col 5}set more {col 22}off`permanently_col'"
-
-		pause on
-		local setDispLocal "`setDispLocal'{break}{col 5}pause {col 22}on"
-
-		set varabbrev off `permanently'
-		local setDispLocal "`setDispLocal'{break}{col 5}set varabbrev {col 22}off`permanently_col'"
-
-		set type float `permanently'
-		local setDispLocal "`setDispLocal'{break}{col 5}set type {col 22}float`permanently_col'"
+    set type float `permanently'
+    local setDispLocal "`setDispLocal'{break}{col 5}set type {col 22}float`permanently_col'"
 
     /***************************************************************************
     ****************************************************************************
 
-			Outputs
+      Outputs
 
     ****************************************************************************
-		***************************************************************************/
+    ***************************************************************************/
 
 
-		/*********************************
+    /*********************************
 
-			Create return value and output message
+      Create return value and output message
 
-		*********************************/
+    *********************************/
 
     * if very quietly is used then supress this info
     if "`veryquietly'" == "" {
 
 
       if "`quietly'" == "" {
-  			noi di ""
-  			noi di as result "{phang}{err:DISCLAIMER:} Due to how settings work in Stata, this command can only attempt to harmonize settings as much as possible across users, but no guarantee can be given that all commands will always behave identically unless the exact same version and type of Stata is used, with the same releases of user-contributed commands installed.{p_end}"
-  			noi di ""
-  			noi di `"`setDispLocal'"'
+        noi di ""
+        noi di as result "{phang}{err:DISCLAIMER:} Due to how settings work in Stata, this command can only attempt to harmonize settings as much as possible across users, but no guarantee can be given that all commands will always behave identically unless the exact same version and type of Stata is used, with the same releases of user-contributed commands installed.{p_end}"
+        noi di ""
+        noi di `"`setDispLocal'"'
 
         * If adopath is used output what was done
         if !missing(`"`adopath'"') {
@@ -302,9 +300,9 @@
         }
       }
 
-			noi di ""
-			noi di as result "{phang}{err:IMPORTANT:} One important setting of this command – the Stata version – cannot be set inside the command due to how this setting works. The setting has been prepared by this command, and you only need to write \`r(version)' after this command (include the apostrophes) for the version setting to be applied.{p_end}"
+      noi di ""
+      noi di as result "{phang}{err:IMPORTANT:} One important setting of this command – the Stata version – cannot be set inside the command due to how this setting works. The setting has been prepared by this command, and you only need to write \`r(version)' after this command (include the apostrophes) for the version setting to be applied.{p_end}"
 
     }
-	}
-	end
+  }
+  end

--- a/src/ado_files/ieboilstart.ado
+++ b/src/ado_files/ieboilstart.ado
@@ -270,27 +270,6 @@
 		set type float `permanently'
 		local setDispLocal "`setDispLocal'{break}{col 5}set type {col 22}float`permanently_col'"
 
-		/*********************************
-			Add custom lines of code if provided
-		*********************************/
-
-		if `"`custom'"' != "" {
-			local setDispLocal `"`setDispLocal'{break} {break}{col 5}{ul:User specified settings:}"'
-			*Create a local with the rowlabel input to be tokenized
-			local custom_code_lines `custom'
-			while `"`custom_code_lines'"' != "" {
-				*Parsing name and label pair
-				gettoken code_line custom_code_lines : custom_code_lines, parse("@")
-				*Removing leadning or trailing spaces
-				local code_line = trim(`"`code_line'"')
-				*Set custom setting
-				local setDispLocal `"`setDispLocal'{break}{col 5}`code_line'"'
-				`code_line'
-				*Parse char is not removed by gettoken
-				local custom_code_lines = subinstr(`"`custom_code_lines'"' ,"@","",1)
-			}
-		}
-
     /***************************************************************************
     ****************************************************************************
 

--- a/src/ado_files/ieboilstart.ado
+++ b/src/ado_files/ieboilstart.ado
@@ -14,11 +14,12 @@
 			and apply it is valid
 		*********************************/
 
-		* Based on versions listed here: https://www.stata.com/support/faqs/resources/history-of-stata/
-		local stata_versions "11 11.0 11.1 11.2 12 12.0 12.1 13 13.0 13.1 14 14.0 14.1 14.2 15 15.0 15.1 16.0 16.1 17.0"
+    * Get target versions from ietoolkit command
+  	ietoolkit
+  	local valid_stata_versions "`r(stata_target_versions)'"
 
-		if `:list versionnumber in stata_versions' == 0 {
-			di as error "{phang}Only recent major releases are allowed. The releases currently allowed are:{break}`stata_versions'{p_end}"
+		if `:list versionnumber in valid_stata_versions' == 0 {
+			di as error "{phang}Only recent major releases are allowed. The releases currently allowed are:{break}`valid_stata_versions'{p_end}"
 			di ""
 			error 198
 			exit

--- a/src/ado_files/ieboilstart.ado
+++ b/src/ado_files/ieboilstart.ado
@@ -76,6 +76,8 @@
         error 198
       }
 
+      local aoutput "{phang}{err:ADOPATH:} "
+
       * Set adopath depending on if strict was used
       if "`aoption'" == "strict" {
         * If strict is used, the replace plus
@@ -89,13 +91,19 @@
           capture adopath - 3
           if _rc local morepaths 0
         }
+
+        local aoutput `"`aoutput'PLUS adopath was set to [`apath']. All other adopaths (apart from BASE) were removed so only programs and ado-files in this PLUS folder is accessible to your code."'
       }
       else {
         * Set PERSONAL path to ado path
         sysdir set  PERSONAL `"`apath'"'
         adopath ++  PERSONAL
         adopath ++  BASE
+
+        local aoutput `"`aoutput'PERSONAL adopath was set to [`apath']. Any other adopath is still availible."'
       }
+
+      local aoutput `"`aoutput' Run {stata adopath} to see your current setting. These settings are restores next time you restart Stata.{p_end}"'
     }
 
     /***************************************************************************
@@ -326,16 +334,28 @@
 
 		*********************************/
 
-		if "`quietly'" == "" & "`veryquietly'" == "" {
-			noi di ""
-			noi di "{phang}{err:DISCLAIMER:} Due to how settings work in Stata, this command can only attempt to harmonize settings as much as possible across users, but no guarantee can be given that all commands will always behave identically unless the exact same version and type of Stata is used, with the same releases of user-contributed commands installed.{p_end}"
-			noi di ""
-			noi di `"`setDispLocal'"'
-		}
+    * if very quietly is used then supress this info
+    if "`veryquietly'" == "" {
 
-		if  "`veryquietly'" == "" {
+
+      if "`quietly'" == "" {
+  			noi di ""
+  			noi di as result "{phang}{err:DISCLAIMER:} Due to how settings work in Stata, this command can only attempt to harmonize settings as much as possible across users, but no guarantee can be given that all commands will always behave identically unless the exact same version and type of Stata is used, with the same releases of user-contributed commands installed.{p_end}"
+  			noi di ""
+  			noi di `"`setDispLocal'"'
+
+        * If adopath is used output what was done
+        if !missing(`"`adopath'"') {
+          noi di ""
+          noi di as result "`aoutput'"
+        }
+      }
+
 			noi di ""
-			noi di "{phang}{err:IMPORTANT:} The most important setting of this command – the version – cannot be set inside the command due to technical reasons. The setting has been prepared by this command, and you only need to write \`r(version)' after this command (include the apostrophes).{p_end}"
-		}
+			noi di as result "{phang}{err:IMPORTANT:} One important setting of this command – the Stata version – cannot be set inside the command due to how this setting works. The setting has been prepared by this command, and you only need to write \`r(version)' after this command (include the apostrophes) for the version setting to be applied.{p_end}"
+
+    }
+
+
 	}
 	end

--- a/src/help_files/ieboilstart.sthlp
+++ b/src/help_files/ieboilstart.sthlp
@@ -40,9 +40,9 @@ See more details {help ieboilstart##desc:below}.
 {synopthdr:options}
 {synoptline}
 {synopt :{opt v:ersionnumber(Stata_version)}}Sets the Stata version
-the project's code should targets{p_end}
+the project's code targets{p_end}
 {synopt :{opt ado:path("path" [, strict])}}Sets the folder where this
-project's ado-files are stored.{p_end}
+project's ado-files are stored{p_end}
 {synopt :{opt noclear}}Makes the command not start by clearing all data{p_end}
 {synopt :{opt q:uietly}}Suppresses most of the command's output{p_end}
 {synopt :{opt veryquietly}}Suppresses all of the command's output{p_end}
@@ -68,11 +68,14 @@ Especially if you want the code to run identically also in the future when
 new versions of Stata and new versions of user-written commands
 have been released.
 The objective of this command is to reduce the risk
-that the code does not generate the same results in different environments,
-but it is not technically possible to fully eliminate this risk.{p_end}
+that a research project's code does not generate the same results
+when running the same code on different computers
+or in different points in the future.
+However, note that it is not technically possible
+to fully eliminate this risk.{p_end}
 
-{pstd}The best practice settings this command use
-can be grouped into the following types:
+{pstd}The best practice settings this command applies
+can be categorized into the following types:
 {it:Stata version}, {it:ado-paths}, and {it:other} settings.{p_end}
 
 {dlgtab:Stata version settings}
@@ -85,20 +88,32 @@ a new version of Stata has been released.
 This can change how the Stata code runs, so for reproducibility,
 it is important to indicate which Stata version this code targets.{p_end}
 
-{pstd}This command uses Stata's built in command {cmd:version} to
+{pstd}This command uses Stata's built-in command {cmd:version} to
 target a script to a specific versions of Stata.
-While this makes the code run more similar to the targeted Stata version,
-it does not guarantee that the code runs identically.
-Setting the Stata version is particularly important for any Stata code
+Different versions of Stata might run the same code slightly differently.
+See many more details {help version:here}.
+Setting the Stata version makes them run the same code more similarly.
+Note that there is no guarantee that two different versions of Stata
+run the same code identically in every single aspects
+even after targeting the same version.
+However, the risk that they do run differently is
+significantly reduced when setting the version.{p_end}
+
+{pstd}Setting the Stata version is particularly important for any Stata code
 containing randomization that is intended to be reproducible.
 Stata occasionally updates the randomization algorithm used between versions.
-See many more details {help version:here}.{p_end}
+The improvement when updating the randomization algorithm
+is unlikely to make any difference to the vast majority of research projects.
+What's important is that to make code with a random process reproducible,
+it must use the exact same algorithm,
+and that is achieved by targeting an exact version.{p_end}
 
-{pstd}Due how {cmd:version} works is it not possible to set
-the Stata version for the rest of the code inside a command like this command.
-Therefore, in order for the version best practices to be applied,
+{pstd}For good reasons, it is not possible to set the Stata version
+for the rest of the code from inside a user-written command.
+Therefore, in order for the version best practice
+to be applied across the project code,
 any user of this command must add {inp:`r(version)'}
-on the immediate subsequent line. See below.{p_end}
+on the immediate subsequent line after {cmdab:ieboilstart}. See below.{p_end}
 
 {phang}{cmdab:ieboilstart} , {it:options}{p_end}{phang}`r(version)'{p_end}
 
@@ -118,15 +133,15 @@ but can also be installed from other sources
 or be custom written for the specific project.
 Code using user-written commands is only reproducible to the highest standard
 if they are using the same versions of these commands.
-This is rarely the case, unless the functionality
-simplified by this command is used.{p_end}
+This is rarely the case, unless the functionality made easily accessible
+in the option {opt adopath()} in this command is used.{p_end}
 
 {pstd}Coordinating that all users in a project team, as well as
 anyone reproducing the results at the same time or in the future,
 have exactly the same version of user-written commands
 installed in their installation of Stata is probably impossible.
 The best practice solution is to set up a project specific folder
-where the commands needed for this project is installed.
+where the commands needed for this project are installed.
 This folder can be shared using a syncing service (ex. DropBox)
 or in version control tools (ex. GitHub).
 Just make sure that if this folder is shared publicly,
@@ -134,33 +149,36 @@ the project is allowed to do so
 for commands not written by anyone in the project.{p_end}
 
 {pstd}In this command, the {opt adopath("path/to/folder")} option specifies
-a folder as the project specific folder for user written commands.
-This allows any program files in that folder to be available to the code
-in addition to the commands already installed in the users Stata installation.
+a folder as the project specific folder for user-written commands.
+This allows any commands in that folder to be available to the code
+in addition to the commands already installed in the user's Stata installation.
 If the sub-option {it:strict} is used,
 as in {opt adopath("path/to/folder", strict)},
 then {ul:only} commands in this folder is available to the code.
-Stata's built-in commands are always available.
+(Stata's built-in commands are always available.)
+This allows a project to make sure that everyone is only using
+the exact version of the user-written command installed in that folder.
 After {it:strict} is used, you can use {inp:ssc install} or {inp:net install}
 to install commands into the project specific folder.{p_end}
 
 {pstd}The scope of adopath setting is the same as for globals.
-This means that the settings are restored to the defaults
-next time Stata is restarted.{p_end}
+This means that the adopath settings done by this command
+are restored to the defaults next time Stata is restarted.{p_end}
 
 {dlgtab:Other settings}
 
 {pstd}It is rare that any of the settings in this category
 is anything a typical user ever needs to worry about.
-These settings mostly prevents that code does not run on a computer as the
-Stata memory management settings has been set
-to a particularly extreme value.
-The one case these settings can be relevant to modify for a user is if
-the code is developed to run on a computer or server with unusual
+These settings mostly prevents that some unusual and outlier memory setting
+is the reason some computer is not able to run
+the code the same way as other computers.
+One example use case where it can be relevant for a user to
+modify these settings is if the code is developed to run
+on a computer or server with unusual
 (for example very small) specifications.{p_end}
 
-{pstd}This command also standardize some settings that could in some cases
-make sure that the code runs differently on different computers.
+{pstd}This command also standardize some settings that could, in some cases,
+could otherwise cause the code to run differently or with interruptions.
 For example, {help set more:set more off},
 {help set varabbrev:set varabbrev off}, {help set type:set type float},
 etc.{p_end}
@@ -169,78 +187,96 @@ etc.{p_end}
 why certain default values were used.{p_end}
 
 {p2colset 5 23 25 2}
-{p2col : Other Settings}Short explanation{p_end}
+{p2col : Other Settings}Explanation{p_end}
 {p2line}
 {pstd}{it: Basic Memory Settings:}{p_end}
-{p2col :{cmdab:set maxvar}}sets the maximum number of variables allowed. The
-	default value is the maximum allowed in the version of Stata used which is 32,767 in Stata MP or SE, and 120,000 in Stata MP 15. A lower maximum
-	number can manually be set by the option {cmdab:maxvar()}. The maxvar is fixed in Stata Small or IC so this setting is ignored when any of
-	those versions of Stata is used. See {help set maxvar:set maxvar}.{p_end}
-{p2col :{cmdab:set matsize}}sets the maximum number of variables that can be included
-	in estimation commands such as {cmd:regress}. The {cmdab:ieboilstart} default value
-	is 400 which is the default value for Stata. A higher value is often allowed but it slows down
-	Stata and is only needed when running very complex analysis. This option can be used to set a higher
-	value, as long as the value does not violate the limitations in the version of Stata used. See {help set matsize:set matsize}.{p_end}
+{p2col :{cmdab:set maxvar}}sets the maximum number of variables allowed.
+The default value is the maximum allowed in the version of Stata.
+A lower maximum number can manually be set by the option {cmdab:maxvar()}.
+This value is fixed in Stata Small or IC,
+so this setting is ignored when any of those versions of Stata is used.
+See {help set maxvar:set maxvar}.{p_end}
+{p2col :{cmdab:set matsize}}sets the maximum number of variables
+that can be included in estimation commands such as {cmd:regress}.
+The default value used in this command is 400 which
+is the default value for Stata.
+A higher value is often allowed but it slows down Stata
+and is only needed when running very complex analysis.
+This option can be used to set a higher value,
+as long as the value does not violate the limitations in
+the versions of Stata this code will be used in.
+See {help set matsize:set matsize}.{p_end}
 {break}
-{pstd}{it: Dynamic Memory Settings (see {help memory:memory} for details and reasons for default values. Few users ever need to change these values):}{p_end}
-{p2col :{cmdab:set min_memory}}sets a lower bound for the amount of memory assigned to Stata. The default value is no lower bound.{p_end}
-{p2col :{cmdab:set max_memory}}sets an upper bound for the amount of memory assigned to Stata. The default is as much as the hardware of the computer allows.{p_end}
-{p2col :{cmdab:set niceness}}defines how quickly Stata releases unused memory back to the computer{p_end}
-{p2col :{cmdab:set segmentsize}}defines how large bundles of data is assigned each time
-Stata request more memory. Too large bundles make Stata occupy an
-unnecessary large part of the computer's memory (that otherwise could
-have been used by other applications), and too small bundles make
-Stata frequently consume processing power requesting new bundles.{p_end}
+{pstd}{it: Dynamic Memory Settings (see {help memory:memory} for default values):}{p_end}
+{p2col :{cmdab:set min_memory}}sets a lower bound
+for the amount of memory assigned to Stata.
+The default value is no lower bound.{p_end}
+{p2col :{cmdab:set max_memory}}sets an upper bound
+for the amount of memory assigned to Stata.
+The default is as much as the hardware of the computer allows.{p_end}
+{p2col :{cmdab:set niceness}}defines how quickly Stata releases
+unused memory back to the computer{p_end}
+{p2col :{cmdab:set segmentsize}}defines how large bundles of data
+is assigned each time Stata request more memory.
+Too large bundles make Stata occupy
+an unnecessary large part of the computer's memory
+(that otherwise could have been used by other applications),
+and too small bundles makes Stata have to interrupt itself to request
+more bundles of memory too frequently{p_end}
 {break}
 {pstd}{it: Code Flow Settings:}{p_end}
-{p2col :{cmdab:set more off}}disables the default setting that Stata stops and
-	waits for the user to press any key each time the output window is full. Long
-	dofiles would take a very long time to run and require constant attention from
-	the user without this setting. Most Stata users always disable the default
-	which is {cmdab:set more on}. See {help set more:set more}.{p_end}
-{p2col :{cmdab:pause on}}allows the usage of the command {cmdab:pause} which can
-	be very useful during debugging. See {help pause:pause}.{p_end}
+{p2col :{cmdab:set more off}}disables the default setting that
+Stata stops and waits for the user to press any key each time
+the output window is full.
+Long dofiles would take a very long time to run and require
+constant attention from the user without this setting.
+Most Stata users always disable the default which is {cmdab:set more on}.
+See {help set more:set more}.{p_end}
+{p2col :{cmdab:pause on}}allows the usage of the command {cmdab:pause}
+which can  be very useful during debugging.
+See {help pause:pause}.{p_end}
 {break}
 {pstd}{it: Variable Settings:}{p_end}
-{p2col :{cmdab:set varabbrev off}}allows users to abbreviate variable names
-similarly to command names such as gen for generate and reg for regress.
-However, while command abbreviation has strict rules constant across data sets, users, and
-Stata versions; variable name abbreviation does not have the same strict rules
-and consistency. While enabling variable abbreviation can speed up coding,
-it is an error-prone technique unless all users using a dofile with
-variable abbreviations organize their coding practices exactly the same
-way. See {help set varabbrev:set varabbrev} for more details and carefully
-consider this caution before enabling variable abbreviations in a
-collaborative dofile.{p_end}
-{p2col :{cmdab:set type float}}sets the default variable type
-when creating a new variable to {it:float}.
-Different default type can lead to differences in randomization
+{p2col :{cmdab:set varabbrev off}}allows users to abbreviate variable names.
+Somewhat similarly to command names abbreviation such as
+{inp:gen} for {inp:generate} and {inp:reg} for {inp:regress}.
+However, command name abbreviations are set up to make sure there is no
+name conflicts that makes the abbreviations ambiguous.
+This is not true for variable name abbreviation and
+code that relies on variable name abbreviations tend to be error prone.
+See {help set varabbrev} for more details and carefully
+consider these words of caution before enabling
+variable name abbreviation in a collaborative dofile.{p_end}
+{p2col :{cmdab:set type float}}sets the default variable type to {it:float}
+when creating a new variable and no type is specified.
+Different default types can lead to differences in randomization
 as this setting affects the precision in the randomization.
 For extremely large dataset the type {it:double} might be required,
 when generating random numbers that is expected to be unique.
 But since that type is twice as storage intensive,
 this command use {it:float} as default,
 and users need to specify {it:double} in the rare cases
-it makes a difference.  {p_end}
+it makes a difference.{p_end}
 {p2line}
 
 {title:Options}
 
 {phang}{opt v:ersionnumber(string)} sets a stable version of Stata
-	for all users. Stata does not (for good reasons) allow a user-written command
-	to alter the version setting from inside a command. Therefore, this option does
-	{ul:nothing} unless "`r(version)'" is included as described in the
-	{help ieboilstart##synt:syntax section}. While the version number cannot be set
-	inside the command code, {cmd:ieboilstart} does two things. First it reminds
-	the user to set the version since it is a required command. Second, it makes
-	sure that the version number used is not too old. A too old version might
-	risk that there are far too big a difference in many commands. Best
-	practice is therefore to keep the same version number throughout a project,
-	unless there is something specific to a newer version that is required for any
-	dofile.
-  Only major and recent versions are allowed in order
-  to reduce errors and complexity.
-	All versions of Stata can be set to run any older version of Stata but not a newer. {p_end}
+for all users. Stata does not (for good reasons) allow a user-written command
+to alter the version setting from inside a command. Therefore, this option does
+{ul:nothing} unless "`r(version)'" is included as described in the
+{help ieboilstart##synt:syntax section}. While the version number cannot be set
+inside the command code, {cmd:ieboilstart} does two things. First it reminds
+the user to set the version since it is a required command. Second, it makes
+sure that the version number used is not too old. A too old version might
+risk that there are far too big a difference in many commands. Best
+practice is therefore to keep the same version number throughout a project,
+unless there is something specific to a newer version
+that is required for any dofile.
+Only major and recent versions are allowed in order
+to reduce errors and complexity.
+All versions of Stata can be set to run
+any older version of Stata but not a newer.{p_end}
 
 {phang}{opt ado:path("path/to/folder" [, strict])} adds the folder specified
 in this option to the {help sysdir:ado-file paths}.
@@ -252,57 +288,62 @@ Read more in {help sysdir} about the {it:PERSONAL} and {it:PLUS} paths.
 When {it:strict} is used the all other ado-paths are removed apart from the
 {it:BASE} path where the built-in Stata commands are stored.
 When preparing a reproducibility package one should use the {it:strict}
-to make sure that all user written commands are saved in the project ado-folder.
+to make sure that all user-written commands are saved in the project ado-folder.
 If a project should eventually be turned into a reproducibility package,
-then the it is easier to use {it:strict} from the beginning and add commands
-as they are used in the code.
-This is easier than in the very end make sure that
-the correct version is installed to the project ado-folder.
+then it is easier to use {it:strict} from the beginning
+and continuously add user-written commands as
+they are introduced to the project's code.
+This is easier compared to, in the very end making sure that
+the correct versions of all user-written commands
+are installed in the project ado-folder.{p_end}
 
-{phang}{opt noclear} prevents the command from clearing/deleting the data set
-	in working memory. No data may be in working memory in order to modify
-	settings for maxvar, min_memory, max_memory and segmentsize. That is why the default
-	is to clear the data set stored in working memory. Working memory is your RAM
-	memory so no data saved to your hard drive will ever be deleted by this command.
-	This command is intended to be placed at the very top of a dofile, so the
-	data needed could be loaded into memory after running {cmd:ieboilstart}. For the
-	reasons above, {cmdab:noclear} and {cmdab:maxvar()} cannot be combined.{p_end}
+{phang}{opt noclear} prevents the command from clearing
+any data set currently loaded into Stata's working memory.
+The default is to clear data as the working memory needs to be empty
+in order to modify settings for maxvar, min_memory, max_memory and segmentsize.
+Nothing saved to hard drive memory will ever be deleted by this command.
+This command is intended to be placed at the very top of a dofile,
+before any data is loaded into working memory.
+For these reasons, {cmdab:noclear} and {cmdab:maxvar()}
+cannot be used together.{p_end}
 
-{phang}{opt q:uietly} suppresses two of three outputs
-this commands generates in the result window.
-The first output is a disclaimer warning the user that there is
-no guarantee that commands will always behave identically.
-The second output is a list of all the settings applied and their values.{p_end}
+{phang}{opt q:uietly} suppresses the most verbose outputs from this command,
+but not the most important outputs.{p_end}
 
-{phang}{opt veryquietly} suppresses the third output this commands generates
-in the result window in addition to the two that {cmd:quietly} is suppressing.
-The third output is a reminder to set the version number using
+{phang}{opt veryquietly} suppresses all the output from this command.
+Including the important reminder to set the version number using
 {inp:`r(version)'} after running the command.
 
-{phang}{opt maxvar(numlist)} manually sets the maximum number of
-variables allowed in a data set. The default is to set the number to the highest
-	allowed. Reducing this number can occasionally improve performance, but modern
-	computers running Impact Evaluations analysis are more likely to
-	face the problem of too few variables allowed than running out of
-	memory.
-  For example, the maximum number allowed in Stata 15.1 is 2047 in Stata IC;
-  32,767 in Stata SE; and 120,000 in Stata MP.
-  This option is ignored for users that use Stata IC or Small Stata.{p_end}
+{phang}{opt maxvar(numlist)} manually sets
+the maximum number of variables allowed in a data set.
+The default is to set the number to
+the highest allowed in the user's version of Stata.
+Reducing this number can occasionally improve performance,
+but it is unlikely to make a difference to a modern computer.
+This option can be used if a project wants to make sure that the code
+can run on smaller versions of Stata or small computers.
+Then the project can use this option to restrict all computers
+to those limitations, so no one write codes exceeding them.{p_end}
 
-{phang}{opt matsize(numlist)} manually sets the maximum number of
-	variables allowed in estimation commands, for example {help reg:regress}.
-	The default is to set the number to the highest allowed in your version of Stata.
-	Reducing this number can occasionally improve performance, but modern
-	computers running Impact Evaluations analysis are more likely
-	to run into problems by allowing too few variables than running out of memory.
-	Although, this is more likely the case with {cmdab:maxvar} than
-	with {cmdab:matsize}. The maximum number allowed is 800 in Stata IC and 11,000 in Stata
-	MP or SE.{p_end}
+{phang}{opt matsize(numlist)} manually sets the maximum number of variables
+allowed in estimation commands, for example {help reg:regress}.
+The default is to set the number to the highest allowed
+in the user's version of Stata.
+Reducing this number can occasionally improve performance,
+but it is unlikely to make a difference to a modern computer.
+This option can be used if a project wants to make sure that the code
+can run on smaller versions of Stata or small computers.
+Then the project can use this option to restrict all computers
+to those limitations, so no one write codes exceeding them.{p_end}
 
-{phang}{opt noperm:anently} is used to not change settings for future sessions
-	of Stata. The default is that all settings are 	set as defaults so that they apply each time Stata
-	starts after using this command. This option disable that. See option permanently in {help memory:memory} for
-	mroe details. {cmd:set more off} is always set permanently.{p_end}
+{phang}{opt noperm:anently} is used to disable that this command
+updates any default settings in a user's installation of Stata.
+For extensively used best practices, this command updates the default settings
+such that they apply even after the user has restarted their Stata session.
+See option permanently in {help memory:memory} for more details.
+The setting {cmd:set more off} is always set permanently,
+regardless of if this option used,
+as it universally agreed within the Stata community to be better.{p_end}
 
 {title:Examples}
 
@@ -347,8 +388,8 @@ after {cmd:ieboilstart} was run like this.
 {phang}Main author: Kristoffer Bjarkefur, DIME Analytics, The World Bank Group
 
 {phang}Please send bug-reports, suggestions and requests for clarifications
-		 writing "ietoolkit ieboilstart" in the subject line to:{break}
-		 dimeanalytics@worldbank.org
+   writing "ietoolkit ieboilstart" in the subject line to:{break}
+   dimeanalytics@worldbank.org
 
 {phang}You can also see the code, make comments to the code, see the version
-		 history of the code, and submit additions or edits to the code through {browse "https://github.com/worldbank/ietoolkit":the GitHub repository of ietoolkit}.{p_end}
+   history of the code, and submit additions or edits to the code through {browse "https://github.com/worldbank/ietoolkit":the GitHub repository of ietoolkit}.{p_end}

--- a/src/help_files/ieboilstart.sthlp
+++ b/src/help_files/ieboilstart.sthlp
@@ -16,7 +16,7 @@ command please see the {browse "https://dimewiki.worldbank.org/wiki/Ieboilstart"
 is to harmonize settings across users.
 However, it is impossible to guarantee that different types of Stata
 (version number, Small/IC/SE/MP or PC/Mac/Linux)
-work exactly the same in every possible context.
+will work exactly the same in every possible context.
 This command does not guarantee against any version discrepancies in Stata
 or in user-contributed commands.
 This command is solely a collection of common practices to reduce the risk
@@ -28,7 +28,9 @@ See more details {help ieboilstart##desc:below}.
 {title:Syntax}
 
 {phang}Note that one important feature of this command requires that
-{inp: `r(version)'} is included on the first line after {cmd: ieboilstart}, as this setting cannot be done inside a user-command.
+{inp: `r(version)'} is written on the first do-file line after {cmd: ieboilstart}, 
+as this setting cannot be done inside a user-command. 
+This will set the Stata version to the correct setting.
 
 {phang}{cmdab:ieboilstart} , {opt v:ersionnumber(Stata_version)}
 [{opt ado:path("path/to/folder" [, strict])}
@@ -40,9 +42,9 @@ See more details {help ieboilstart##desc:below}.
 {synopthdr:options}
 {synoptline}
 {synopt :{opt v:ersionnumber(Stata_version)}}Sets the Stata version
-the project's code targets{p_end}
+for all subsequent code execution (required){p_end}
 {synopt :{opt ado:path("path" [, strict])}}Sets the folder where this
-project's ado-files are stored{p_end}
+project's ado-files or user-written commands are stored (required for standalone reproducibility packages){p_end}
 {synopt :{opt noclear}}Makes the command not start by clearing all data{p_end}
 {synopt :{opt q:uietly}}Suppresses most of the command's output{p_end}
 {synopt :{opt veryquietly}}Suppresses all of the command's output{p_end}
@@ -64,11 +66,11 @@ permanently set some best practice memory settings{p_end}
 collaboration and reproducibility within a research project.
 Making the same Stata code consistently generate the same results when
 run on other people's computers is harder than what it first might seem.
-Especially if you want the code to run identically also in the future when
-new versions of Stata and new versions of user-written commands
+This is especially true in order to ensure that Stata code will function identically in the future,
+even if new versions of Stata and user-written commands (such as those on SSC)
 have been released.
 The objective of this command is to reduce the risk
-that a research project's code does not generate the same results
+that a research project's code changes its results
 when running the same code on different computers
 or in different points in the future.
 However, note that it is not technically possible
@@ -76,26 +78,27 @@ to fully eliminate this risk.{p_end}
 
 {pstd}The best practice settings this command applies
 can be categorized into the following types:
-{it:Stata version}, {it:ado-paths}, and {it:other} settings.{p_end}
+{it:Stata version}, {it:adopath} management, and {it:other} settings.{p_end}
 
 {dlgtab:Stata version settings}
 
 {pstd}Research projects often span over several years,
-or is required to be reproducible for anyone in the future
+and are required to be reproducible for anyone in the future
 reviewing the results.
-After several years have past, it is likely that
+After several years have passed, it is likely that
 a new version of Stata has been released.
 This can change how the Stata code runs, so for reproducibility,
-it is important to indicate which Stata version this code targets.{p_end}
+it is important to indicate which Stata version this code was written in.{p_end}
 
 {pstd}This command uses Stata's built-in command {cmd:version} to
-target a script to a specific versions of Stata.
-Different versions of Stata might run the same code slightly differently.
+execute a script using a specific version of Stata (and its syntax).
+Different versions of Stata might run the same code slightly differently,
+or they may have changed syntax or functionality for built-in commands entirely.
 See many more details {help version:here}.
 Setting the Stata version makes them run the same code more similarly.
 Note that there is no guarantee that two different versions of Stata
 run the same code identically in every single aspects
-even after targeting the same version.
+even after selecting the same version.
 However, the risk that they do run differently is
 significantly reduced when setting the version.{p_end}
 
@@ -103,17 +106,19 @@ significantly reduced when setting the version.{p_end}
 containing randomization that is intended to be reproducible.
 Stata occasionally updates the randomization algorithm used between versions.
 The improvement when updating the randomization algorithm
-is unlikely to make any difference to the vast majority of research projects.
+is unlikely to make any difference to the vast majority of research projects,
+but any change to {it: any} command might cause the same Stata code to obtain different random numbers
+when used in the future.
 What's important is that to make code with a random process reproducible,
 it must use the exact same algorithm,
-and that is achieved by targeting an exact version.{p_end}
+and that is achieved by selecting an exact Stata version.{p_end}
 
 {pstd}For good reasons, it is not possible to set the Stata version
 for the rest of the code from inside a user-written command.
 Therefore, in order for the version best practice
 to be applied across the project code,
 any user of this command must add {inp:`r(version)'}
-on the immediate subsequent line after {cmdab:ieboilstart}. See below.{p_end}
+on the immediate subsequent do-file line after {cmdab:ieboilstart}. See below.{p_end}
 
 {phang}{cmdab:ieboilstart} , {it:options}{p_end}{phang}`r(version)'{p_end}
 
@@ -125,16 +130,21 @@ are used, then the version should be set in the main file,
 and only results generated when running all code from the main file
 should be considered reproducible.{p_end}
 
-{dlgtab:Ado-path settings}
+{dlgtab:Adopath settings}
 
 {pstd}Many research projects use user-written commands in the code.
 These commands are commonly installed from {help ssc:SSC},
 but can also be installed from other sources
 or be custom written for the specific project.
-Code using user-written commands is only reproducible to the highest standard
-if they are using the same versions of these commands.
+Code using user-written commands is only permanently reproducible
+if future users have {it: exactly} the same versions of all commands.
 This is rarely the case, unless the functionality made easily accessible
 in the option {opt adopath()} in this command is used.{p_end}
+This functionality requires that all user-written commands for a single project
+be stored in a single unique location.
+This ensures that the corresponding code can be maintained, packaged, and archived
+with the precise outputs those versions of code create.
+User-written commands never guarantee backwards compatibility or random-output stability when they are updated.
 
 {pstd}Coordinating that all users in a project team, as well as
 anyone reproducing the results at the same time or in the future,
@@ -142,8 +152,8 @@ have exactly the same version of user-written commands
 installed in their installation of Stata is probably impossible.
 The best practice solution is to set up a project specific folder
 where the commands needed for this project are installed.
-This folder can be shared using a syncing service (ex. DropBox)
-or in version control tools (ex. GitHub).
+This folder can be shared using a syncing service (for example, Dropbox)
+or in version control tools such as Github, where the rest of the project code is stored.
 Just make sure that if this folder is shared publicly,
 the project is allowed to do so
 for commands not written by anyone in the project.{p_end}

--- a/src/help_files/ieboilstart.sthlp
+++ b/src/help_files/ieboilstart.sthlp
@@ -6,118 +6,172 @@ help for {hi:ieboilstart}
 
 {title:Title}
 
-{phang}{cmdab:ieboilstart} {hline 2} harmonizes Stata settings across team members in the same project.
+{phang}{cmdab:ieboilstart} {hline 2} applies best practices for
+collaboration and reproducibility within a project.{p_end}
 
 {phang2}For a more descriptive discussion on the intended usage and workflow of this
 command please see the {browse "https://dimewiki.worldbank.org/wiki/Ieboilstart":DIME Wiki}.
 
-{phang}{hi:DISCLAIMER} {hline 1} Due to technical reasons, it is
-impossible to guarantee that different types of Stata (version number, Small/IC/SE/MP
-or PC/Mac/Linux) work exactly the same in every possible context. This command does not
-guarantee against any version discrepancies in Stata or in under-contributed commands,
-it is solely a collection of common practices to reduce the risk of the same code running
-differently on different computers. See more details {help ieboilstart##comp:below}.
+{phang}{hi:DISCLAIMER} {hline 1} One objective of this command
+is to harmonize settings across users.
+However, it is impossible to guarantee that different types of Stata
+(version number, Small/IC/SE/MP or PC/Mac/Linux)
+work exactly the same in every possible context.
+This command does not guarantee against any version discrepancies in Stata
+or in user-contributed commands.
+This command is solely a collection of common practices to reduce the risk
+that the same code generates different outputs
+when running on different computers.
+See more details {help ieboilstart##desc:below}.
 
 {marker synt}{...}
 {title:Syntax}
 
-{phang}Note that due to technical requirements in Stata, to include the most
-	important setting - version() - in this command you must include the second line below.{p_end}
+{phang}Note that one important feature of this command requires that
+{inp: `r(version)'} is included on the first line after {cmd: ieboilstart}, as this setting cannot be done inside a user-command.
 
-{pmore}
-{cmdab:ieboilstart} , {cmdab:v:ersionnumber(}{it:version_number}{cmd:)}  [{it:optional_options}]{break}
-`r(version)'
-
-{phang}The second line "`r(version)'" uses the command {help version} to set the same Stata version across all
-	users. "`r(version)'" is identical to setting the version to the version number set in {cmdab:v:ersionnumber()} but
-	both helps standardize this setting across different parts in the project and function as a reminder to
-	set the version number. {p_end}
+{phang}{cmdab:ieboilstart} , {opt v:ersionnumber(Stata_version)}
+[{opt ado:path("path/to/folder" [, strict])}
+{opt noclear} {opt q:uietly} {opt veryquietly}
+{it:{help ieboilstart##mset:memory_options}}]{p_end}{phang}`r(version)'{p_end}
 
 {marker opts}{...}
-{synoptset 20}{...}
+{synoptset 28}{...}
 {synopthdr:options}
 {synoptline}
-{synopt :{cmdab:v:ersionnumber(}{it:string}{cmd:)}}sets a stable version of Stata
-	for all users. This option does {ul:nothing} unless "`r(version)'" is included as in the example above.{p_end}
-{synopt :{cmdab:maxvar(}{it:numlist}{cmd:)}}manually sets the maximum number of
-	variables allowed in a data set. The default if omitted is the maximum number of variables
-	allowed depending on the version of Stata used.{p_end}
-{synopt :{cmdab:matsize(}{it:numlist}{cmd:)}}manually sets the maximum number of
-	variables allowed in an estimation command, for example {help regress:regress}.
-	The default if omitted is 400.{p_end}
-{synopt :{cmdab:noclear}}prevents the command from clearing all data which some settings
-	require. Best practice is to use this command before opening any data.{p_end}
-{synopt :{cmdab:q:uietly}}suppresses the output with the disclaimer and the list
-	of settings.{p_end}
-{synopt :{cmdab:veryquietly}}does what {cmdab:quietly} does, but also suppresses the
-	reminder to include "`r(version)'".{p_end}
-{synopt :{cmdab:setmem(}{it:string}{cmd:)}}manually sets the memory for	Stata 11 users.{p_end}
-{synopt :{cmdab:c:ustom(}{it:string}{cmd:)}}allows the user to enter custom lines
-	of code to be added.{p_end}
-{synopt :{cmdab:noperm:anently(}{it:string}{cmd:)}}is used to not change settings for future sessions of Stata.{p_end}
+{synopt :{opt v:ersionnumber(Stata_version)}}Sets the Stata version
+the project's code should targets{p_end}
+{synopt :{opt ado:path("path" [, strict])}}Sets the folder where this
+project's ado-files are stored.{p_end}
+{synopt :{opt noclear}}Makes the command not start by clearing all data{p_end}
+{synopt :{opt q:uietly}}Suppresses most of the command's output{p_end}
+{synopt :{opt veryquietly}}Suppresses all of the command's output{p_end}
+
+{marker mset}{...}
+{pstd}{it:Memory options}{p_end}
+{synopt :{opt maxvar(numlist)}}Manually specify maximum
+number of variables allowed{p_end}
+{synopt :{opt matsize(numlist)}}Manually specify maximum
+number of variables allowed in estimation commands{p_end}
+{synopt :{opt noperm:anently}}Disable the default to
+permanently set some best practice memory settings{p_end}
 {synoptline}
 
 {marker desc}{...}
 {title:Description}
 
-{pstd}{cmdab:ieboilstart} standardizes best practice settings across all users using for a project.
-	Such standardized code is usually referred to as boilerplate code, and that is
-	where {cmdab:ieboilstart} gets its name. Standardizing the boilerplate code
-	in a project reduces the risk that code behaves differently across users regardless of
-	what version and type of Stata they are running.
+{pstd}{cmdab:ieboilstart} applies best practices for
+collaboration and reproducibility within a research project.
+Making the same Stata code consistently generate the same results when
+run on other people's computers is harder than what it first might seem.
+Especially if you want the code to run identically also in the future when
+new versions of Stata and new versions of user-written commands
+have been released.
+The objective of this command is to reduce the risk
+that the code does not generate the same results in different environments,
+but it is not technically possible to fully eliminate this risk.{p_end}
 
-{pstd}A command like this is impossible to make comprehensive in terms of versions control. Therefore,
-	the ambition of this command is only to provide a convenient way to include boilerplate code based
-	on commonly used best practices, which is much better than having no boilerplate code at all. The default
-	values used are the values that are standard in boilerplate code for dofiles written for Impact
-	Evaluations at DIME, World Bank. Suggestions for additions or improvements are very welcomed. See
-	the {help ieboilstart##auth:author} section	for contact details.
+{pstd}The best practice settings this command use
+can be grouped into the following types:
+{it:Stata version}, {it:ado-paths}, and {it:other} settings.{p_end}
 
-{marker comp}{...}
-{title:Compatibility Across Different Stata:}
+{dlgtab:Stata version settings}
 
-{pstd}{cmdab:ieboilstart} sets settings that increases compatibility between Stata 11.0-15.0, Stata Small/IC/SE/MP and Stata for	PC/Mac/Linux. {it:Increase compatibility} does not mean an absolute guarantee that all code will always
-	work the same in different types of Stata. That is technically impossible. {it:Increase compatibility} here means reducing the risk of code working differently in different types of Stata.
+{pstd}Research projects often span over several years,
+or is required to be reproducible for anyone in the future
+reviewing the results.
+After several years have past, it is likely that
+a new version of Stata has been released.
+This can change how the Stata code runs, so for reproducibility,
+it is important to indicate which Stata version this code targets.{p_end}
 
-{pstd}{cmdab:ieboilstart} does sometimes apply different settings for different users as all settings does not work for all versions and types of Stata. For example, new memory settings were introduced in Stata 12 and {inp:set maxvar} is not allowed in Stata IC. {cmdab:ieboilstart} is implemented to set the settings in each version and type of Stata that reduces the risk of errors when different users run the same code, but the only way to eliminate the risk completely, is to use exactly the same version of Stata.
+{pstd}This command uses Stata's built in command {cmd:version} to
+target a script to a specific versions of Stata.
+While this makes the code run more similar to the targeted Stata version,
+it does not guarantee that the code runs identically.
+Setting the Stata version is particularly important for any Stata code
+containing randomization that is intended to be reproducible.
+Stata occasionally updates the randomization algorithm used between versions.
+See many more details {help version:here}.{p_end}
 
-{pstd}In addition to version control, {cmdab:ieboilstart} allows a project to 	standardize user preference settings such as {help set varabbrev:varabbrev} that 		can cause code to behave differently across users.
+{pstd}Due how {cmd:version} works is it not possible to set
+the Stata version for the rest of the code inside a command like this command.
+Therefore, in order for the version best practices to be applied,
+any user of this command must add {inp:`r(version)'}
+on the immediate subsequent line. See below.{p_end}
 
-{title:Important Details on Version Setting:}
+{phang}{cmdab:ieboilstart} , {it:options}{p_end}{phang}`r(version)'{p_end}
 
-{pstd}Impact Evaluations and other research projects often span over many
-	years, which means that the same code is likely to run in different versions
-	of Stata. Stata provides a method to reduce the risk of discrepancies due to this. See {help version:version} settings for more details. This method is included in {cmdab:ieboilstart}, however, {cmd:version} is mainly intended for making code written in Stata 11 work
-	in Stata 14 and not necessarily the other way around. Setting the version is still best practice and perhaps the most important setting in {cmdab:ieboilstart}. Read the {help ieboilstart##synt:syntax section} on the extra step required for {cmdab:ieboilstart} to set the version.{p_end}
+{pstd}The version setting has the scope of a local,
+meaning that it expires when a dofile
+and all sub-dofiles it is calling are completed. If
+{browse "https://dimewiki.worldbank.org/Master_Do-files":main/master do-files}
+are used, then the version should be set in the main file,
+and only results generated when running all code from the main file
+should be considered reproducible.{p_end}
 
-{pstd}{hi:Warning:} Any dofiles containing randomization {ul:{hi:MUST}} set the version number
-	as Stata occasionally makes updates to its randomization algorithm between versions. A dofile including random assignment
-	or random sampling is therefore not necessarily stable across different versions of Stata,
-	unless the dofile has a version number explicitly set in the beginning of the file.{p_end}
+{dlgtab:Ado-path settings}
 
-	{pstd}The version setting has the scope of a local, meaning that it expires when a dofile and all sub-dofiles it is calling are completed. Therefore, set the version in your master dofile {ul:and} in every single dofile using randomization. This will make your randomization stable even if another user would only run the specific dofile with the randomization.{p_end}
+{pstd}Many research projects use user-written commands in the code.
+These commands are commonly installed from {help ssc:SSC},
+but can also be installed from other sources
+or be custom written for the specific project.
+Code using user-written commands is only reproducible to the highest standard
+if they are using the same versions of these commands.
+This is rarely the case, unless the functionality
+simplified by this command is used.{p_end}
 
-{title:Details on Memory Settings:}
+{pstd}Coordinating that all users in a project team, as well as
+anyone reproducing the results at the same time or in the future,
+have exactly the same version of user-written commands
+installed in their installation of Stata is probably impossible.
+The best practice solution is to set up a project specific folder
+where the commands needed for this project is installed.
+This folder can be shared using a syncing service (ex. DropBox)
+or in version control tools (ex. GitHub).
+Just make sure that if this folder is shared publicly,
+the project is allowed to do so
+for commands not written by anyone in the project.{p_end}
 
-{pstd}In Stata versions before Stata 12, memory was assigned statically from the
-	computer memory, meaning that there was a fixed amount of memory assigned to Stata
-	regardless if required it or not. Stata would crash if it went over that fixed limit
-	when for example increasing the data set or running a complex calculation. In Stata
-	12 and more recent versions, this is done dynamically, meaning that Stata is assigned
-	a little bit of memory when it is starts and assigned additional memory dynamically
-	as needed. The only memory limit is the hardware limits on the computer it is running
-	on.
+{pstd}In this command, the {opt adopath("path/to/folder")} option specifies
+a folder as the project specific folder for user written commands.
+This allows any program files in that folder to be available to the code
+in addition to the commands already installed in the users Stata installation.
+If the sub-option {it:strict} is used,
+as in {opt adopath("path/to/folder", strict)},
+then {ul:only} commands in this folder is available to the code.
+Stata's built-in commands are always available.
+After {it:strict} is used, you can use {inp:ssc install} or {inp:net install}
+to install commands into the project specific folder.{p_end}
 
-{pstd}The fixed memory in Stata 11 was assigned by the command {cmdab:set memory}. This
-	command is simply ignored in Stata 12 or later. Instead the dynamic memory setting
-	can be fine tuned with {cmdab:min_memory}, {cmdab:max_memory}, {cmdab:niceness} and
-	{cmdab:segmentsize}, although even highly advanced users rarely have to worry about these settings as long as they are set to the recommended default values
-	(which this command ensures that they are).
+{pstd}The scope of adopath setting is the same as for globals.
+This means that the settings are restored to the defaults
+next time Stata is restarted.{p_end}
 
-{p2colset 5 22 24 2}
-{p2col : Memory Settings}Short explanation{p_end}
+{dlgtab:Other settings}
+
+{pstd}It is rare that any of the settings in this category
+is anything a typical user ever needs to worry about.
+These settings mostly prevents that code does not run on a computer as the
+Stata memory management settings has been set
+to a particularly extreme value.
+The one case these settings can be relevant to modify for a user is if
+the code is developed to run on a computer or server with unusual
+(for example very small) specifications.{p_end}
+
+{pstd}This command also standardize some settings that could in some cases
+make sure that the code runs differently on different computers.
+For example, {help set more:set more off},
+{help set varabbrev:set varabbrev off}, {help set type:set type float},
+etc.{p_end}
+
+{pstd}See the tables below for a discussion of which settings used and
+why certain default values were used.{p_end}
+
+{p2colset 5 23 25 2}
+{p2col : Other Settings}Short explanation{p_end}
 {p2line}
-{pstd}{it: Basic Settings:}{p_end}
+{pstd}{it: Basic Memory Settings:}{p_end}
 {p2col :{cmdab:set maxvar}}sets the maximum number of variables allowed. The
 	default value is the maximum allowed in the version of Stata used which is 32,767 in Stata MP or SE, and 120,000 in Stata MP 15. A lower maximum
 	number can manually be set by the option {cmdab:maxvar()}. The maxvar is fixed in Stata Small or IC so this setting is ignored when any of
@@ -133,22 +187,12 @@ differently on different computers. See more details {help ieboilstart##comp:bel
 {p2col :{cmdab:set max_memory}}sets an upper bound for the amount of memory assigned to Stata. The default is as much as the hardware of the computer allows.{p_end}
 {p2col :{cmdab:set niceness}}defines how quickly Stata releases unused memory back to the computer{p_end}
 {p2col :{cmdab:set segmentsize}}defines how large bundles of data is assigned each time
-			Stata request more memory. Too large bundles make Stata occupy an
-			unnecessary large part of the computer's memory (that otherwise could
-			have been used by other applications), and too small bundles make
-			Stata frequently consume processing power requesting new bundles.{p_end}
+Stata request more memory. Too large bundles make Stata occupy an
+unnecessary large part of the computer's memory (that otherwise could
+have been used by other applications), and too small bundles make
+Stata frequently consume processing power requesting new bundles.{p_end}
 {break}
-{pstd}{it: Static Memory Settings (only applicable in Stata 11)}{p_end}
-{p2col :{cmdab:set memory}}sets the amount of static memory assigned to Stata. {p_end}
-{p2line}
-
-{pstd}{hi:{ul:Other Settings:}}{break}The other settings are included as they are either very
-	commonly preferred or reduces the risk of errors for users that do not yet fully understand
-	the implication of setting these settings to other values than what is recommended. These
-	settings can be reverted to personal preferences after running {cmdab:ieboilstart} or by using the {cmd:custom()} option.{p_end}
-{p2colset 5 24 26 2}
-{p2col : Other Settings}Short explanation{p_end}
-{p2line}
+{pstd}{it: Code Flow Settings:}{p_end}
 {p2col :{cmdab:set more off}}disables the default setting that Stata stops and
 	waits for the user to press any key each time the output window is full. Long
 	dofiles would take a very long time to run and require constant attention from
@@ -156,21 +200,33 @@ differently on different computers. See more details {help ieboilstart##comp:bel
 	which is {cmdab:set more on}. See {help set more:set more}.{p_end}
 {p2col :{cmdab:pause on}}allows the usage of the command {cmdab:pause} which can
 	be very useful during debugging. See {help pause:pause}.{p_end}
+{break}
+{pstd}{it: Variable Settings:}{p_end}
 {p2col :{cmdab:set varabbrev off}}allows users to abbreviate variable names
-		similarly to command names such as gen for generate and reg for regress.
-		However, while command abbreviation has strict rules constant across data sets, users, and
-		Stata versions; variable name abbreviation does not have the same strict rules
-		and consistency. While enabling variable abbreviation can speed up coding,
-		it is an error-prone technique unless all users using a dofile with
-		variable abbreviations organize their coding practices exactly the same
-		way. See {help set varabbrev:set varabbrev} for more details and carefully
-		consider this caution before enabling variable abbreviations in a
-		collaborative dofile.{p_end}
+similarly to command names such as gen for generate and reg for regress.
+However, while command abbreviation has strict rules constant across data sets, users, and
+Stata versions; variable name abbreviation does not have the same strict rules
+and consistency. While enabling variable abbreviation can speed up coding,
+it is an error-prone technique unless all users using a dofile with
+variable abbreviations organize their coding practices exactly the same
+way. See {help set varabbrev:set varabbrev} for more details and carefully
+consider this caution before enabling variable abbreviations in a
+collaborative dofile.{p_end}
+{p2col :{cmdab:set type float}}sets the default variable type
+when creating a new variable to {it:float}.
+Different default type can lead to differences in randomization
+as this setting affects the precision in the randomization.
+For extremely large dataset the type {it:double} might be required,
+when generating random numbers that is expected to be unique.
+But since that type is twice as storage intensive,
+this command use {it:float} as default,
+and users need to specify {it:double} in the rare cases
+it makes a difference.  {p_end}
 {p2line}
 
 {title:Options}
 
-{phang}{cmdab:v:ersionnumber(}{it:string}{cmd:)} sets a stable version of Stata
+{phang}{opt v:ersionnumber(string)} sets a stable version of Stata
 	for all users. Stata does not (for good reasons) allow a user-written command
 	to alter the version setting from inside a command. Therefore, this option does
 	{ul:nothing} unless "`r(version)'" is included as described in the
@@ -181,22 +237,59 @@ differently on different computers. See more details {help ieboilstart##comp:bel
 	risk that there are far too big a difference in many commands. Best
 	practice is therefore to keep the same version number throughout a project,
 	unless there is something specific to a newer version that is required for any
-	dofile. Only major and recent versions are allowed in order to reduce errors and
-	complexity. The valid versions are 11.0, 11.1, 11.2, 12.0, 12.1, 13.0, 13.1,
-	14.0, 14.1, 14.2, 15.0, 15.1, and all versions without decimals. However, it is recommended
-	to use a .1 over a .0 version. .1 is free of charge if you already have the
-	corresponding .0 and .1 includes bug fixes to the functions introduced in .0.
+	dofile.
+  Only major and recent versions are allowed in order
+  to reduce errors and complexity.
 	All versions of Stata can be set to run any older version of Stata but not a newer. {p_end}
 
-{phang}{cmdab:maxvar(}{it:numlist}{cmd:)} manually sets the maximum number of
-	variables allowed in a data set. The default is to set the number to the highest
+{phang}{opt ado:path("path/to/folder" [, strict])} adds the folder specified
+in this option to the {help sysdir:ado-file paths}.
+When {it:strict} is not used this option sets the {it:PERSONAL} path
+to the path specified in this command.
+When {it:strict} is used then this option instead sets
+that path to the {it:PLUS} path.
+Read more in {help sysdir} about the {it:PERSONAL} and {it:PLUS} paths.
+When {it:strict} is used the all other ado-paths are removed apart from the
+{it:BASE} path where the built-in Stata commands are stored.
+When preparing a reproducibility package one should use the {it:strict}
+to make sure that all user written commands are saved in the project ado-folder.
+If a project should eventually be turned into a reproducibility package,
+then the it is easier to use {it:strict} from the beginning and add commands
+as they are used in the code.
+This is easier than in the very end make sure that
+the correct version is installed to the project ado-folder.
+
+{phang}{opt noclear} prevents the command from clearing/deleting the data set
+	in working memory. No data may be in working memory in order to modify
+	settings for maxvar, min_memory, max_memory and segmentsize. That is why the default
+	is to clear the data set stored in working memory. Working memory is your RAM
+	memory so no data saved to your hard drive will ever be deleted by this command.
+	This command is intended to be placed at the very top of a dofile, so the
+	data needed could be loaded into memory after running {cmd:ieboilstart}. For the
+	reasons above, {cmdab:noclear} and {cmdab:maxvar()} cannot be combined.{p_end}
+
+{phang}{opt q:uietly} suppresses two of three outputs
+this commands generates in the result window.
+The first output is a disclaimer warning the user that there is
+no guarantee that commands will always behave identically.
+The second output is a list of all the settings applied and their values.{p_end}
+
+{phang}{opt veryquietly} suppresses the third output this commands generates
+in the result window in addition to the two that {cmd:quietly} is suppressing.
+The third output is a reminder to set the version number using
+{inp:`r(version)'} after running the command.
+
+{phang}{opt maxvar(numlist)} manually sets the maximum number of
+variables allowed in a data set. The default is to set the number to the highest
 	allowed. Reducing this number can occasionally improve performance, but modern
 	computers running Impact Evaluations analysis are more likely to
 	face the problem of too few variables allowed than running out of
-	memory. The maximum number allowed in Stata 15.1 is 2047 in Stata IC; 32,767 in Stata SE;
-	and 120,000 in Stata MP. This setting is ignored for users that use Stata IC or Small Stata.{p_end}
+	memory.
+  For example, the maximum number allowed in Stata 15.1 is 2047 in Stata IC;
+  32,767 in Stata SE; and 120,000 in Stata MP.
+  This option is ignored for users that use Stata IC or Small Stata.{p_end}
 
-{phang}{cmdab:matsize(}{it:numlist}{cmd:)} manually sets the maximum number of
+{phang}{opt matsize(numlist)} manually sets the maximum number of
 	variables allowed in estimation commands, for example {help reg:regress}.
 	The default is to set the number to the highest allowed in your version of Stata.
 	Reducing this number can occasionally improve performance, but modern
@@ -206,26 +299,7 @@ differently on different computers. See more details {help ieboilstart##comp:bel
 	with {cmdab:matsize}. The maximum number allowed is 800 in Stata IC and 11,000 in Stata
 	MP or SE.{p_end}
 
-{phang}{cmdab:noclear} prevents the command from clearing/deleting the data set
-	in working memory. No data may be in working memory in order to modify
-	settings for maxvar, min_memory, max_memory and segmentsize. That is why the default
-	is to clear the data set stored in working memory. Working memory is your RAM
-	memory so no data saved to your hard drive will ever be deleted by this command.
-	This command is intended to be placed at the very top of a dofile, so the
-	data needed could be loaded into memory after running {cmd:ieboilstart}. For the
-	reasons above, {cmdab:noclear} and {cmdab:maxvar()} cannot be combined.{p_end}
-
-{phang}{cmdab:q:uietly} suppresses two of three outputs this commands generates in the result window. The first output is a disclaimer warning the user that there is no guarantee that commands will always behave identically. The second output is a list of all the settings applied and their values..{p_end}
-
-{phang}{cmd:veryquietly} suppresses the third output this commands generates in the result window in addition to the two that {cmd:quietly} is suppressing. The third output is a reminder to set the version number using "`r(version)'" after running the command.
-
-{phang}{cmdab:c:ustom(}{it:string}{cmd:)} allows the user to add one or multiple custom lines of code. Each line of code should be separated with a "@". See example 2
-	below for more details.{p_end}
-
-{phang}{cmdab:setmem(}{it:string}{cmd:)}This option is only relevant for users of Stata 11. This value must be an integer followed by the letter B, K, M or G. The default if omitted is 50M. Cannot be used if
-	versionnumber() is set to version 12.0 or more recent. See {help set memory} for more details. This link will only display options relevant to Stata 11 when clicking it in Stata 11. Otherwise it will show the options relevant to Stata 12 and later.
-
-{phang}{cmdab:noperm:anently(}{it:string}{cmd:)} is used to not change settings for future sessions
+{phang}{opt noperm:anently} is used to not change settings for future sessions
 	of Stata. The default is that all settings are 	set as defaults so that they apply each time Stata
 	starts after using this command. This option disable that. See option permanently in {help memory:memory} for
 	mroe details. {cmd:set more off} is always set permanently.{p_end}
@@ -234,32 +308,41 @@ differently on different computers. See more details {help ieboilstart##comp:bel
 
 {pstd}{hi:Example 1.}
 
-{pmore}{inp:ieboilstart, versionnumber(11.1)}
-{break}`r(version)'
+{phang2}{cmd: ieboilstart}, {opt versionnumber(12.1)}{p_end}
+{phang2}{inp:`r(version)'}{p_end}
 
-{pmore}After running the two lines of code above all users will run their version
- of Stata as if the version was  11.1. That means that anyone who bought or
- upgraded Stata after June 2010 can use the command and all commands will behave
-  identically for all those users. All other settings have been set to common
-	best practice values.
+{pmore}After running the two lines of code above
+all users will run their version of Stata as if the version was 12.1.
+That means that anyone who bought or upgraded their Stata
+to version 12.1 or a more recent version can run this code
+and will behave as identical as possible.{p_end}
 
 {pstd}{hi:Example 2.}
 
-{pmore}{inp:ieboilstart, versionnumber(12.1) custom(ssc install estout @ ssc install winsor)}
-{break}`r(version)'
+{phang2}{inp:local proj_ado} {it:"/path/to/project/code/ado"}{p_end}
+{phang2}{cmd:ieboilstart}, {opt versionnumber(15.1)}
+{opt adopath("`proj_ado'", strict)}{p_end}
+{phang2}{inp:`r(version)'}{p_end}
 
-{pmore}In the example above, the version is set to 12.1. When running this command, it also makes sure that the user has the two commands {inp:estout} and {inp:winsor} installed.
-
-{title:Acknowledgements}
-
-{phang}I would like to acknowledge the help in testing and proofreading and suggestions I
-	received in relation to this command and help file from (in alphabetic order):{p_end}
-{pmore}Michell Dong{break}John Dundas{break}Paula Gonzales{break}Seungmin Lee{break}Srujith Lingala{break}William Lisowski{break}Daniel Klein
+{pmore}In this example the Stata version is set to 15.1
+and the ado-folders are updated.
+Let's say a project folder is located at {it:"/path/to/project"} and
+inside it there is a folder called {it:code} where all code files are located.
+This would be a great location for a folder called {it:ado} that would be
+the project specific ado-folder.
+Since the sub-option {it:strict} is used this is the only place
+where Stata would look for commands that are not built-in commands.
+Any commands installed by SSC before updating
+this ado-path is no longer available.
+Any such commands that is needed in the code for this project needs
+to be installed again in the project specific ado-folder.
+Which can be done using {inp:ssc install ...} the regular way
+after {cmd:ieboilstart} was run like this.
 
 {marker auth}{...}
 {title:Author}
 
-{phang}All commands in ietoolkit is developed by DIME Analytics at DECIE, The World Bank's unit for Development Impact Evaluations.
+{phang}All commands in ietoolkit is developed by DIME Analytics at DIME, The World Bank's department for Development Impact Evaluations.
 
 {phang}Main author: Kristoffer Bjarkefur, DIME Analytics, The World Bank Group
 


### PR DESCRIPTION
The introduction of this option makes the best practices about setting adopaths for reproducibility projects more easily available. 