### PR TITLE
ieboilstart : improve output reminder for r(version)

### DIFF
--- a/src/ado_files/ieboilstart.ado
+++ b/src/ado_files/ieboilstart.ado
@@ -310,7 +310,7 @@
       }
 
       noi di ""
-      noi di as result "{phang}{err:IMPORTANT:} One important setting of this command – the Stata version – cannot be set inside the command due to how this setting works. The setting has been prepared by this command, and you only need to write \`r(version)' after this command (include the apostrophes) for the version setting to be applied.{p_end}"
+      noi di as result "{phang}{err:IMPORTANT:} One setting of this command requires that \`r(version)' is run on the immediate line after this command. Include the qoutes \` and ' in \`r(version)'. This sets the Stata version which cannot be done for this purpose inside the command. This message will show regardless if this is already done. Read more on this requirment in the {help ieboilstart :help file}.{p_end}"
 
     }
   }


### PR DESCRIPTION
Received feedback that the reminder to include `r(version)` on the subsequent line was confusing. 

How about this:

![image](https://user-images.githubusercontent.com/15911801/234228829-7f823c8c-1af7-4bff-93d5-db04864b4a1c.png)

Image represents what is in this PR as of e91fcdd3f23af263c4acc1f30d2b0715be93fa95