### PR TITLE
iesave - issue 347 - bug if multiple idvars and missing values exist

### DIFF
--- a/run/iesave/iesave1.do
+++ b/run/iesave/iesave1.do
@@ -107,6 +107,34 @@
 			version(`stata_ver')
 		assert _rc == 459
 
+        /*********************
+		      Mutliple IDvars with missing values
+		*********************/
+
+ 		* Load auto
+		sysuse auto, clear
+        
+        * Create ids that are only unique in combination
+        gen village = foreign 
+        sort village make
+        by  village : gen village_hhid = _n
+         
+        * First test that it works without missing
+		iesave "`version_folder'/id_3.dta", 	///
+			idvars(village village_hhid) version(15) replace
+ 
+ 		*Add this file to list of expected files
+		local expected_files `"`expected_files' "id_3.dta""'
+        
+        *  Create some missing vars
+        replace village = . in 5
+        replace village_hhid = . in 65
+        
+        * Run iesave and test for expected error
+        cap iesave "~/delete-out/err_id_3.dta", ///
+            idvars(village village_hhid) version(15) replace
+        assert _rc == 459
+        
 		/*********************
 		   absence of userinfo
 		*********************/

--- a/run/iesave/iesave2.do
+++ b/run/iesave/iesave2.do
@@ -62,5 +62,15 @@
 
 	* Report with csv without path
 	iesave "`out'/auto-csv.dta", id(make) version(17.0) report(csv) replace
+	
+// Two ID vars -----------------------------------------------------------------
 
+	iesave "`out'/auto-2id.dta", id(make foreign) version(17.0) report replace
+	
+	replace foreign = . in 1
+	
+	cap	iesave "`out'/auto-2id.dta", id(make foreign) version(17.0) report replace
+	assert _rc == 459
+	
+	
 ************************************************************************ The end.

--- a/run/iesave/outputs/iesave2/auto-2id.md
+++ b/run/iesave/outputs/iesave2/auto-2id.md
@@ -2,11 +2,11 @@ This report was created by the Stata command iesave (version 7.2). Read more abo
 
 - **Number of observations:** 74
 - **Number of variables:** 12
-- **ID variable(s):** make
+- **ID variable(s):** make foreign
 - **.dta version used:** 14
 - **Data signature:** 74:12(71728):2155345365:1865188037
-- **Last saved by:** luizaandrade - BFI-33299
-- **Last saved at:** 17:01:38 28 Oct 2023
+- **Last saved by:** User info withheld, see option userinfo in command iesave.
+- **Last saved at:** 17:01:39 28 Oct 2023
 
 ## Variable type: String
 

--- a/run/iesave/outputs/iesave2/auto-csv.csv
+++ b/run/iesave/outputs/iesave2/auto-csv.csv
@@ -6,7 +6,7 @@ ID variable(s):,make
 .dta version used:,14
 Data signature:,74:12(71728):2155345365:1865188037
 Last saved by:,User info withheld, see option userinfo in command iesave.
-Last saved at:,12:07:04 11 Apr 2023
+Last saved at:,17:01:38 28 Oct 2023
 
 Variable type: String
 Name,Label,Type,Complete obs,Number of levels

--- a/run/iesave/outputs/iesave2/auto-noalpha.md
+++ b/run/iesave/outputs/iesave2/auto-noalpha.md
@@ -5,8 +5,8 @@ This report was created by the Stata command iesave (version 7.2). Read more abo
 - **ID variable(s):** make
 - **.dta version used:** 14
 - **Data signature:** 74:12(71728):2155345365:1865188037
-- **Last saved by:** wb462869 - PCD85M04J3
-- **Last saved at:** 12:07:04 11 Apr 2023
+- **Last saved by:** luizaandrade - BFI-33299
+- **Last saved at:** 17:01:38 28 Oct 2023
 
 ## Variable type: String
 

--- a/run/iesave/outputs/iesave2/auto.md
+++ b/run/iesave/outputs/iesave2/auto.md
@@ -6,7 +6,7 @@ This report was created by the Stata command iesave (version 7.2). Read more abo
 - **.dta version used:** 14
 - **Data signature:** 74:12(71728):2155345365:1865188037
 - **Last saved by:** User info withheld, see option userinfo in command iesave.
-- **Last saved at:** 12:07:03 11 Apr 2023
+- **Last saved at:** 17:01:38 28 Oct 2023
 
 ## Variable type: String
 

--- a/run/iesave/outputs/iesave2/my-path.csv
+++ b/run/iesave/outputs/iesave2/my-path.csv
@@ -5,8 +5,8 @@ Number of variables:,12
 ID variable(s):,make
 .dta version used:,14
 Data signature:,74:12(71728):2155345365:1865188037
-Last saved by:,wb462869 - PCD85M04J3
-Last saved at:,12:07:04 11 Apr 2023
+Last saved by:,luizaandrade - BFI-33299
+Last saved at:,17:01:38 28 Oct 2023
 
 Variable type: String
 Name,Label,Type,Complete obs,Number of levels

--- a/run/iesave/outputs/iesave2/my-path.md
+++ b/run/iesave/outputs/iesave2/my-path.md
@@ -5,8 +5,8 @@ This report was created by the Stata command iesave (version 7.2). Read more abo
 - **ID variable(s):** make
 - **.dta version used:** 14
 - **Data signature:** 74:12(71728):2155345365:1865188037
-- **Last saved by:** wb462869 - PCD85M04J3
-- **Last saved at:** 12:07:04 11 Apr 2023
+- **Last saved by:** luizaandrade - BFI-33299
+- **Last saved at:** 17:01:38 28 Oct 2023
 
 ## Variable type: String
 

--- a/src/ado_files/iesave.ado
+++ b/src/ado_files/iesave.ado
@@ -159,14 +159,16 @@ qui {
 	capture isid `idvars'
 	if _rc {
 
-		*Test if there is missing values in the idvars
-		capture assert !missing(`idvars')
-		if _rc {
-			count if missing(`idvars')
-			noi di as error "{phang}The ID variable(s) `idvars' have missing values in `r(N)' observation(s). The ID variable(s) need to be fully identifying, meaning that missing values (., .a, .b ... .z) or the empty string are not allowed.{p_end}"
-			noi list `idvars' if missing(`idvars')
-			noi di ""
-		}
+    foreach idvar of local idvars {
+      *Test if there is missing values in the idvars
+      capture assert !missing(`idvar')
+      if _rc {
+        count if missing(`idvar')
+        noi di as error "{phang}The ID variable(s) `idvar' have missing values in `r(N)' observation(s). The ID variable(s) need to be fully identifying, meaning that missing values (., .a, .b ... .z) or the empty string are not allowed.{p_end}"
+        noi list `idvars' if missing(`idvar')
+        noi di ""
+      }
+    }
 
 		*Test if there are duplciates in the idvars
 		tempvar iedup


### PR DESCRIPTION
Missing values in idvars should lead to an error by `iesave` as idvars should be fully identifying. However, it was a bug that this error was unhandled. 

This is now fixed by having the command test for missing values in the idvars one at the time.